### PR TITLE
Use cookies for JWT auth

### DIFF
--- a/AI Website/ChatGPT-Micro-Cap-Experiment/requirements.txt
+++ b/AI Website/ChatGPT-Micro-Cap-Experiment/requirements.txt
@@ -5,3 +5,4 @@ matplotlib==3.8.4
 Flask==3.0.2
 Flask-Bcrypt==1.0.1
 PyJWT==2.8.0
+Flask-Cors==4.0.0

--- a/AI Website/ChatGPT-Micro-Cap-Experiment/templates/login.html
+++ b/AI Website/ChatGPT-Micro-Cap-Experiment/templates/login.html
@@ -32,6 +32,7 @@ document.getElementById('register-form').addEventListener('submit', async e => {
     const res = await fetch('/register', {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
+        credentials: 'include',
         body: JSON.stringify({
             username: document.getElementById('reg-username').value,
             email: document.getElementById('reg-email').value,
@@ -47,31 +48,32 @@ document.getElementById('login-form').addEventListener('submit', async e => {
     const res = await fetch('/login', {
         method: 'POST',
         headers: {'Content-Type': 'application/json'},
+        credentials: 'include',
         body: JSON.stringify({
             email: document.getElementById('login-email').value,
             password: document.getElementById('login-password').value
         })
     });
     const data = await res.json();
-    if (res.ok) {
-        localStorage.setItem('token', data.token);
-    }
     output.textContent = JSON.stringify(data, null, 2);
 });
 
 
 document.getElementById('protected-btn').addEventListener('click', async () => {
-    const token = localStorage.getItem('token');
     const res = await fetch('/protected', {
-        headers: {'Authorization': 'Bearer ' + token}
+        credentials: 'include'
     });
     const data = await res.json();
     output.textContent = JSON.stringify(data, null, 2);
 });
 
-document.getElementById('logout-btn').addEventListener('click', () => {
-    localStorage.removeItem('token');
-    output.textContent = 'Logged out';
+document.getElementById('logout-btn').addEventListener('click', async () => {
+    const res = await fetch('/logout', {
+        method: 'POST',
+        credentials: 'include'
+    });
+    const data = await res.json();
+    output.textContent = JSON.stringify(data, null, 2);
 });
 </script>
 </body>


### PR DESCRIPTION
## Summary
- issue JWT in an HttpOnly, Secure, SameSite cookie and read it server-side
- drop localStorage in favor of credentialed fetch calls and add logout endpoint
- include Flask-Cors for cookie-based auth

## Testing
- `python -m py_compile 'AI Website/ChatGPT-Micro-Cap-Experiment/app.py'`


------
https://chatgpt.com/codex/tasks/task_e_6892935e3a9083248c7ac38d5dbef65b