### PR TITLE
Use ChatGPT logs as public samples

### DIFF
--- a/AI Website/ChatGPT-Micro-Cap-Experiment/Scripts and CSV Files/sample_chatgpt_portfolio.csv
+++ b/AI Website/ChatGPT-Micro-Cap-Experiment/Scripts and CSV Files/sample_chatgpt_portfolio.csv
@@ -1,4 +1,0 @@
-Date,Ticker,Shares,Cost Basis,Stop Loss,Current Price,Total Value,PnL,Action,Cash Balance,Total Equity
-2024-01-01,ABC,10,5.00,4.00,5.50,55,5,HOLD,,
-2024-01-01,XYZ,20,2.50,2.00,2.75,55,5,HOLD,,
-2024-01-01,TOTAL,,,,,110,10,,0,110

--- a/AI Website/ChatGPT-Micro-Cap-Experiment/app.py
+++ b/AI Website/ChatGPT-Micro-Cap-Experiment/app.py
@@ -21,7 +21,9 @@ bcrypt = Bcrypt(app)
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 DATA_DIR = os.path.join(BASE_DIR, 'Scripts and CSV Files')
 DATABASE = os.path.join(BASE_DIR, 'users.db')
-SAMPLE_PORTFOLIO = os.path.join(DATA_DIR, 'sample_chatgpt_portfolio.csv')
+# Use ChatGPT's actual logs as the publicly viewable samples
+SAMPLE_PORTFOLIO = os.path.join(DATA_DIR, 'chatgpt_portfolio_update.csv')
+SAMPLE_TRADE_LOG = os.path.join(DATA_DIR, 'chatgpt_trade_log.csv')
 
 
 def ensure_user_files(username: str) -> Tuple[str, str, str]:
@@ -185,6 +187,16 @@ def serve_sample_portfolio_js():
     return send_from_directory('.', 'sample_portfolio.js')
 
 
+@app.route('/sample-trade-log')
+def sample_trade_log_page():
+    return send_from_directory('templates', 'sample_trade_log.html')
+
+
+@app.route('/sample_trade_log.js')
+def serve_sample_trade_log_js():
+    return send_from_directory('.', 'sample_trade_log.js')
+
+
 @app.route('/register', methods=['POST'])
 def register():
     data = request.get_json() or {}
@@ -333,6 +345,13 @@ def read_sample_portfolio():
     return positions, total_equity
 
 
+def read_sample_trade_log():
+    if not os.path.exists(SAMPLE_TRADE_LOG):
+        return []
+    with open(SAMPLE_TRADE_LOG, newline='') as f:
+        return list(csv.DictReader(f))
+
+
 @app.route('/api/trade', methods=['POST'])
 @token_required
 def api_trade(user_id):
@@ -464,6 +483,12 @@ def api_trade(user_id):
 def api_sample_portfolio():
     positions, total_equity = read_sample_portfolio()
     return jsonify({'positions': positions, 'total_equity': total_equity})
+
+
+@app.route('/api/sample-trade-log')
+def api_sample_trade_log():
+    trades = read_sample_trade_log()
+    return jsonify({'trades': trades})
 
 
 @app.route('/api/portfolio')

--- a/AI Website/ChatGPT-Micro-Cap-Experiment/sample_trade_log.js
+++ b/AI Website/ChatGPT-Micro-Cap-Experiment/sample_trade_log.js
@@ -1,0 +1,35 @@
+document.addEventListener('DOMContentLoaded', () => {
+    async function loadSampleTradeLog() {
+        try {
+            const res = await fetch('/api/sample-trade-log');
+            if (!res.ok) throw new Error('Failed to load sample trade log');
+            const data = await res.json();
+            const tbody = document.getElementById('tradeLogTableBody');
+            tbody.innerHTML = '';
+            data.trades.forEach(t => {
+                const tr = document.createElement('tr');
+                tr.innerHTML = `
+                    <td>${t.Date}</td>
+                    <td>${t.Ticker}</td>
+                    <td>${t['Shares Bought']}</td>
+                    <td>${t['Buy Price']}</td>
+                    <td>${t['Cost Basis']}</td>
+                    <td>${t['PnL']}</td>
+                    <td>${t.Reason}</td>
+                    <td>${t['Shares Sold']}</td>
+                    <td>${t['Sell Price']}</td>`;
+                tbody.appendChild(tr);
+            });
+        } catch (err) {
+            console.error(err);
+            const el = document.getElementById('errorMessage');
+            if (el) {
+                el.textContent = 'Failed to load sample trade log';
+                el.classList.remove('visually-hidden');
+            }
+        }
+    }
+
+    loadSampleTradeLog();
+});
+

--- a/AI Website/ChatGPT-Micro-Cap-Experiment/templates/home.html
+++ b/AI Website/ChatGPT-Micro-Cap-Experiment/templates/home.html
@@ -74,7 +74,8 @@
         <div class="login-link">
             <a href="/signin">Sign Up</a> |
             <a href="/login">Log In</a> |
-            <a href="/sample-portfolio">View Sample Portfolio</a>
+            <a href="/sample-portfolio">View Sample Portfolio</a> |
+            <a href="/sample-trade-log">View Sample Trade Log</a>
         </div>
     </section>
 </body>

--- a/AI Website/ChatGPT-Micro-Cap-Experiment/templates/login.html
+++ b/AI Website/ChatGPT-Micro-Cap-Experiment/templates/login.html
@@ -26,7 +26,8 @@
         <button type="submit">Login</button>
         <p id="error" class="error-message" role="alert"></p>
     </form>
-    <p><a href="/sample-portfolio">View Sample Portfolio</a></p>
+    <p><a href="/sample-portfolio">View Sample Portfolio</a> |
+       <a href="/sample-trade-log">View Sample Trade Log</a></p>
 </div>
 <script>
 document.getElementById('login-form').addEventListener('submit', async e => {

--- a/AI Website/ChatGPT-Micro-Cap-Experiment/templates/sample_trade_log.html
+++ b/AI Website/ChatGPT-Micro-Cap-Experiment/templates/sample_trade_log.html
@@ -1,0 +1,52 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Sample Trade Log</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="/styles.css" />
+</head>
+<body>
+    <header>
+        <h1>Sample Trade Log</h1>
+        <nav>
+            <ul class="nav-links">
+                <li><a href="/">Home</a></li>
+                <li><a href="/login">Login</a></li>
+            </ul>
+        </nav>
+    </header>
+    <main>
+        <div id="errorMessage" class="visually-hidden" role="alert"></div>
+        <section id="trade-log">
+            <h2>Trade Log</h2>
+            <div class="table-container">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Date</th>
+                            <th>Ticker</th>
+                            <th>Shares Bought</th>
+                            <th>Buy Price</th>
+                            <th>Cost Basis</th>
+                            <th>PnL</th>
+                            <th>Reason</th>
+                            <th>Shares Sold</th>
+                            <th>Sell Price</th>
+                        </tr>
+                    </thead>
+                    <tbody id="tradeLogTableBody"></tbody>
+                </table>
+            </div>
+        </section>
+    </main>
+    <footer>
+        <p>&copy; 2024 ChatGPT Micro-Cap Experiment. All rights reserved.</p>
+    </footer>
+    <script src="/sample_trade_log.js"></script>
+</body>
+</html>
+


### PR DESCRIPTION
## Summary
- Replace outdated sample CSV with real `chatgpt_portfolio_update.csv` and `chatgpt_trade_log.csv` files, making them accessible as built‑in sample data.
- Expose sample trade log alongside the portfolio through new Flask routes, HTML template, and JavaScript loader.
- Update home and login pages with links to the new sample trade log and remove the obsolete sample file.

## Testing
- `python -m py_compile AI Website/ChatGPT-Micro-Cap-Experiment/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68936ada744c83248726f581a831de7d