### PR TITLE
Display sample trade log beneath sample portfolio

### DIFF
--- a/AI Website/ChatGPT-Micro-Cap-Experiment/templates/sample_portfolio.html
+++ b/AI Website/ChatGPT-Micro-Cap-Experiment/templates/sample_portfolio.html
@@ -46,10 +46,32 @@
                 </table>
             </div>
         </section>
+        <section id="trade-log">
+            <h2>Trade Log</h2>
+            <div class="table-container">
+                <table>
+                    <thead>
+                        <tr>
+                            <th>Date</th>
+                            <th>Ticker</th>
+                            <th>Shares Bought</th>
+                            <th>Buy Price</th>
+                            <th>Cost Basis</th>
+                            <th>PnL</th>
+                            <th>Reason</th>
+                            <th>Shares Sold</th>
+                            <th>Sell Price</th>
+                        </tr>
+                    </thead>
+                    <tbody id="tradeLogTableBody"></tbody>
+                </table>
+            </div>
+        </section>
     </main>
     <footer>
         <p>&copy; 2024 ChatGPT Micro-Cap Experiment. All rights reserved.</p>
     </footer>
     <script src="/sample_portfolio.js"></script>
+    <script src="/sample_trade_log.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- Add sample trade log table below the sample portfolio.
- Include script to fetch sample trade log data.

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68936d8c9150832486617174583c1d60