### PR TITLE
Add sample portfolio Matplotlib chart

### DIFF
--- a/AI Website/ChatGPT-Micro-Cap-Experiment/templates/sample.html
+++ b/AI Website/ChatGPT-Micro-Cap-Experiment/templates/sample.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <title>Sample Portfolio</title>
+</head>
+<body>
+    <h1>Sample Portfolio Equity History</h1>
+    <img src="/sample_chart.png" alt="Equity history chart" />
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Serve new `/sample` page displaying an equity history chart rendered with Matplotlib.
- Stream chart image from `/sample_chart.png` generated from public `chatgpt_portfolio_update.csv` data.
- Reuse existing sample CSV dataset instead of duplicating `chatgpt_portfolio.csv`.

## Testing
- `pytest` (no tests found)


------
https://chatgpt.com/codex/tasks/task_e_6893750939188324b5f3b54b84cf0417