### PR TITLE
Render sample equity chart client-side

### DIFF
--- a/AI Website/ChatGPT-Micro-Cap-Experiment/sample_portfolio.js
+++ b/AI Website/ChatGPT-Micro-Cap-Experiment/sample_portfolio.js
@@ -29,5 +29,35 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
+    async function loadEquityChart() {
+        try {
+            const res = await fetch('/api/sample-equity-history');
+            if (!res.ok) throw new Error('Failed to load equity history');
+            const data = await res.json();
+            const ctx = document.getElementById('equityChart').getContext('2d');
+            new Chart(ctx, {
+                type: 'line',
+                data: {
+                    labels: data.map(d => d.Date),
+                    datasets: [{
+                        label: 'Total Equity',
+                        data: data.map(d => parseFloat(d['Total Equity'])),
+                        borderColor: 'rgba(75, 192, 192, 1)',
+                        backgroundColor: 'rgba(75, 192, 192, 0.2)',
+                        tension: 0.1,
+                    }]
+                },
+                options: {
+                    scales: {
+                        y: { beginAtZero: false }
+                    }
+                }
+            });
+        } catch (err) {
+            console.error(err);
+        }
+    }
+
     loadSamplePortfolio();
+    loadEquityChart();
 });

--- a/AI Website/ChatGPT-Micro-Cap-Experiment/templates/sample_portfolio.html
+++ b/AI Website/ChatGPT-Micro-Cap-Experiment/templates/sample_portfolio.html
@@ -31,7 +31,7 @@
         </section>
         <section id="graphs">
             <h2>Equity History</h2>
-            <img src="/sample_chart.png" width="800" height="400" alt="Sample portfolio equity history" />
+            <canvas id="equityChart" width="800" height="400" aria-label="Sample portfolio equity history" role="img"></canvas>
         </section>
         <section id="portfolio">
             <h2>Portfolio</h2>
@@ -75,6 +75,7 @@
     <footer>
         <p>&copy; 2024 ChatGPT Micro-Cap Experiment. All rights reserved.</p>
     </footer>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="/sample_portfolio.js"></script>
     <script src="/sample_trade_log.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- Replace static sample chart image with a Canvas element and load Chart.js from a CDN.
- Add client-side logic to fetch sample equity history and render a line chart with Chart.js.

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68939517f0f883249576c83f300c648a