### PR TITLE
Embed generated performance graph

### DIFF
--- a/AI Website/ChatGPT-Micro-Cap-Experiment/sample_portfolio.js
+++ b/AI Website/ChatGPT-Micro-Cap-Experiment/sample_portfolio.js
@@ -29,35 +29,5 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
-    async function loadEquityChart() {
-        try {
-            const res = await fetch('/api/sample-equity-history');
-            if (!res.ok) throw new Error('Failed to load equity history');
-            const data = await res.json();
-            const ctx = document.getElementById('equityChart').getContext('2d');
-            new Chart(ctx, {
-                type: 'line',
-                data: {
-                    labels: data.map(d => d.Date),
-                    datasets: [{
-                        label: 'Total Equity',
-                        data: data.map(d => parseFloat(d['Total Equity'])),
-                        borderColor: 'rgba(75, 192, 192, 1)',
-                        backgroundColor: 'rgba(75, 192, 192, 0.2)',
-                        tension: 0.1,
-                    }]
-                },
-                options: {
-                    scales: {
-                        y: { beginAtZero: false }
-                    }
-                }
-            });
-        } catch (err) {
-            console.error(err);
-        }
-    }
-
     loadSamplePortfolio();
-    loadEquityChart();
 });

--- a/AI Website/ChatGPT-Micro-Cap-Experiment/templates/sample_portfolio.html
+++ b/AI Website/ChatGPT-Micro-Cap-Experiment/templates/sample_portfolio.html
@@ -31,7 +31,7 @@
         </section>
         <section id="graphs">
             <h2>Equity History</h2>
-            <canvas id="equityChart" width="800" height="400" aria-label="Sample portfolio equity history" role="img"></canvas>
+            <img src="/sample_chart.png" alt="Sample portfolio equity history" width="800" height="400" />
         </section>
         <section id="portfolio">
             <h2>Portfolio</h2>
@@ -75,7 +75,6 @@
     <footer>
         <p>&copy; 2024 ChatGPT Micro-Cap Experiment. All rights reserved.</p>
     </footer>
-    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
     <script src="/sample_portfolio.js"></script>
     <script src="/sample_trade_log.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- render the portfolio vs S&P 500 comparison from `Generate_Graph.py` as a PNG served at `/sample_chart.png`
- show this chart on `sample_portfolio.html` via an `<img>` and drop Chart.js
- simplify `sample_portfolio.js` to only load portfolio data

## Testing
- `python -m py_compile app.py`
- `python -m py_compile "Scripts and CSV Files/Generate_Graph.py"`
- `python - <<'PY'
from app import app, sample_chart_png
with app.test_request_context():
    resp = sample_chart_png()
    print(resp)
PY` *(fails: HTTPSConnectionPool(host='fc.yahoo.com', port=443): Max retries exceeded with url: / (Caused by ProxyError('Unable to connect to proxy', OSError('Tunnel connection failed: 403 Forbidden'))))*

------
https://chatgpt.com/codex/tasks/task_e_689399751de08324a738778ac6589ab8