### PR TITLE
feat: add portfolio processing endpoint and button

### DIFF
--- a/portfolio_app/app.py
+++ b/portfolio_app/app.py
@@ -8,6 +8,7 @@ import os
 import csv
 from typing import Tuple
 import yfinance as yf
+from trading_script import process_portfolio
 
 try:  # Optional Streamlit integration for session state
     import streamlit as st
@@ -636,6 +637,14 @@ def get_equity_history(user_id: int):
 @token_required
 def api_equity_history(user_id):
     return jsonify(get_equity_history(user_id))
+
+
+@app.route('/api/process-portfolio', methods=['POST'])
+@token_required
+def api_process_portfolio(user_id):
+    """Trigger portfolio processing for the authenticated user."""
+    process_portfolio(user_id)
+    return jsonify({'message': 'Portfolio processed'})
 
 
 if __name__ == '__main__':

--- a/portfolio_app/index.html
+++ b/portfolio_app/index.html
@@ -53,6 +53,7 @@
 
         <section id="portfolio">
             <h2>Portfolio</h2>
+            <button id="processPortfolioBtn">Process Portfolio</button>
             <div class="table-container">
                 <table>
                     <caption class="visually-hidden">Current portfolio positions</caption>

--- a/portfolio_app/script.js
+++ b/portfolio_app/script.js
@@ -194,4 +194,21 @@ document.addEventListener('DOMContentLoaded', () => {
             }
         });
     }
+
+    const processBtn = document.getElementById('processPortfolioBtn');
+    if (processBtn) {
+        processBtn.addEventListener('click', async () => {
+            try {
+                const res = await fetch('/api/process-portfolio', {
+                    method: 'POST',
+                    headers: { Authorization: `Bearer ${token}` },
+                });
+                if (!res.ok) throw new Error('Failed to process portfolio');
+                alert('Portfolio processed successfully');
+                await loadPortfolio();
+            } catch (err) {
+                showError('Failed to process portfolio', err);
+            }
+        });
+    }
 });


### PR DESCRIPTION
## Summary
- add `/api/process-portfolio` endpoint protected by JWT that triggers `process_portfolio`
- add a dashboard button and JS handler to call the new endpoint and refresh data

## Testing
- `python -m py_compile portfolio_app/app.py`
- `node --check portfolio_app/script.js`


------
https://chatgpt.com/codex/tasks/task_e_6893a286668083249177e6059dbfc7cd