### PR TITLE
Add process portfolio control to portfolio view

### DIFF
--- a/portfolio_app/sample_portfolio.js
+++ b/portfolio_app/sample_portfolio.js
@@ -30,4 +30,27 @@ document.addEventListener('DOMContentLoaded', () => {
     }
 
     loadSamplePortfolio();
+
+    const token = localStorage.getItem('token');
+    const processBtn = document.getElementById('processPortfolioBtn');
+    if (processBtn) {
+        processBtn.addEventListener('click', async () => {
+            if (!token) {
+                alert('Please log in to process the portfolio');
+                return;
+            }
+            try {
+                const res = await fetch('/api/process-portfolio', {
+                    method: 'POST',
+                    headers: { Authorization: `Bearer ${token}` }
+                });
+                if (!res.ok) throw new Error('Failed to process portfolio');
+                alert('Portfolio processed successfully');
+                await loadSamplePortfolio();
+            } catch (err) {
+                console.error(err);
+                alert('Failed to process portfolio');
+            }
+        });
+    }
 });

--- a/portfolio_app/templates/sample_portfolio.html
+++ b/portfolio_app/templates/sample_portfolio.html
@@ -35,6 +35,7 @@
         </section>
         <section id="portfolio">
             <h2>Portfolio</h2>
+            <button id="processPortfolioBtn">Process Portfolio</button>
             <div class="table-container">
                 <table>
                     <thead>


### PR DESCRIPTION
## Summary
- Add a **Process Portfolio** button to the portfolio view
- Wire the button to trigger the portfolio processing API for logged-in users

## Testing
- `python -m py_compile portfolio_app/app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893a57da85c83248a5e4922998b1944