### PR TITLE
Improve trade error handling in manual buy/sell workflow

### DIFF
--- a/portfolio_app/script.js
+++ b/portfolio_app/script.js
@@ -186,8 +186,14 @@ document.addEventListener('DOMContentLoaded', () => {
                     body: JSON.stringify(payload),
                 });
                 if (!res.ok) {
-                    const errData = await res.json();
-                    showError(errData.message || 'Trade failed');
+                    let msg = 'Trade failed';
+                    try {
+                        const errData = await res.json();
+                        if (errData && errData.message) msg = errData.message;
+                    } catch (_) {
+                        // Response might not be JSON; keep default message
+                    }
+                    showError(msg);
                     return;
                 }
                 tradeForm.reset();


### PR DESCRIPTION
## Summary
- Handle non-JSON error responses from `/api/trade` so users always see a helpful message

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893b991beb4832497e537ab941b26cf