### PR TITLE
Display trade errors below form

### DIFF
--- a/portfolio_app/index.html
+++ b/portfolio_app/index.html
@@ -74,6 +74,7 @@
 
         <section id="trade-form">
             <h2>Place Trade</h2>
+            <div id="tradeErrorMessage" class="visually-hidden" role="alert" aria-live="polite"></div>
             <form id="tradeForm">
                 <label class="visually-hidden" for="trade-ticker">Ticker</label>
                 <input type="text" id="trade-ticker" placeholder="Ticker" required>

--- a/portfolio_app/script.js
+++ b/portfolio_app/script.js
@@ -10,9 +10,9 @@ document.addEventListener('DOMContentLoaded', () => {
         return;
     }
 
-    function showError(message, err) {
+    function showError(message, err, elementId = 'errorMessage') {
         if (err) console.error(err);
-        const el = document.getElementById('errorMessage');
+        const el = document.getElementById(elementId);
         if (el) {
             el.textContent = message;
             el.classList.remove('visually-hidden');
@@ -165,6 +165,8 @@ document.addEventListener('DOMContentLoaded', () => {
     if (tradeForm) {
         tradeForm.addEventListener('submit', async (e) => {
             e.preventDefault();
+            const tradeErrorEl = document.getElementById('tradeErrorMessage');
+            if (tradeErrorEl) tradeErrorEl.classList.add('visually-hidden');
             const payload = {
                 ticker: document.getElementById('trade-ticker').value.trim().toUpperCase(),
                 action: document.getElementById('trade-action').value,
@@ -199,14 +201,14 @@ document.addEventListener('DOMContentLoaded', () => {
                             /* ignore */
                         }
                     }
-                    showError(msg);
+                    showError(msg, undefined, 'tradeErrorMessage');
                     return;
                 }
                 tradeForm.reset();
                 await loadPortfolio();
                 await loadTradeLog();
             } catch (err) {
-                showError('Trade failed', err);
+                showError('Trade failed', err, 'tradeErrorMessage');
             }
         });
     }


### PR DESCRIPTION
## Summary
- Add dedicated trade error container in trade form
- Update client script to show trade failure messages under the form

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893c56be96483248f0a947e158d60f3