### PR TITLE
Prompt for starting cash based on cash file presence

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,8 +54,7 @@ Visualization tools — Matplotlib graphs comparing ChatGPT vs Index
 
 Logs & trade data — Auto-saved logs for transparency
 
-Starting balance prompt — New users without trade history are asked to set a
-cash balance (up to $100k)
+Starting balance prompt — Users without a recorded cash balance are asked to set one (up to $100k)
 
 # Why This Matters
 AI is being hyped across every industry, but can it really manage money without guidance?

--- a/portfolio_app/app.py
+++ b/portfolio_app/app.py
@@ -101,18 +101,10 @@ def get_user_files(user_id: int) -> Tuple[str, str, str, str]:
 
 
 def user_needs_cash(user_id: int) -> bool:
-    """Return True if the user has no trade history and no starting cash."""
+    """Return True if the user's cash file is missing or empty."""
 
-    _, _, trade_log, cash_file = get_user_files(user_id)
-
-    has_trades = False
-    if os.path.exists(trade_log) and os.path.getsize(trade_log) > 0:
-        with open(trade_log, newline='') as f:
-            reader = csv.DictReader(f)
-            has_trades = any(True for _ in reader)
-
-    has_cash = os.path.exists(cash_file) and os.path.getsize(cash_file) > 0
-    return (not has_trades) and (not has_cash)
+    _, _, _, cash_file = get_user_files(user_id)
+    return not (os.path.exists(cash_file) and os.path.getsize(cash_file) > 0)
 
 
 def is_valid_ticker(ticker: str) -> bool:

--- a/portfolio_app/script.js
+++ b/portfolio_app/script.js
@@ -24,11 +24,8 @@ document.addEventListener('DOMContentLoaded', () => {
     init();
 
     async function init() {
-        let hasPositions = await loadPortfolio();
-        if (!hasPositions) {
-            await checkStartingCash();
-            await loadPortfolio();
-        }
+        await checkStartingCash();
+        await loadPortfolio();
         loadEquityHistory();
         loadTradeLog();
     }


### PR DESCRIPTION
## Summary
- Always call the starting cash check on dashboard load
- Determine the need for starting cash solely by the cash file
- Update documentation to reflect cash balance check

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6893fcb022cc832483d4b242f078daa7