### PR TITLE
Reset cash balance when user files missing or empty

### DIFF
--- a/portfolio_app/app.py
+++ b/portfolio_app/app.py
@@ -38,7 +38,13 @@ def ensure_user_files(username: str) -> Tuple[str, str, str]:
     trade_log = os.path.join(DATA_DIR, f"{username}_trade_log.csv")
     cash_file = os.path.join(DATA_DIR, f"{username}_cash.txt")
 
-    if not os.path.exists(portfolio):
+    portfolio_missing = not os.path.exists(portfolio)
+    trade_log_missing = not os.path.exists(trade_log)
+    cash_missing_or_empty = not (
+        os.path.exists(cash_file) and os.path.getsize(cash_file) > 0
+    )
+
+    if portfolio_missing:
         with open(portfolio, 'w', newline='') as f:
             writer = csv.writer(f)
             writer.writerow([
@@ -55,7 +61,7 @@ def ensure_user_files(username: str) -> Tuple[str, str, str]:
                 'Total Equity',
             ])
 
-    if not os.path.exists(trade_log):
+    if trade_log_missing:
         with open(trade_log, 'w', newline='') as f:
             writer = csv.writer(f)
             writer.writerow([
@@ -70,9 +76,9 @@ def ensure_user_files(username: str) -> Tuple[str, str, str]:
                 'Sell Price',
             ])
 
-    if not os.path.exists(cash_file):
-        # Create an empty cash file. A starting balance will be set later
-        # if the user has no trading history.
+    if cash_missing_or_empty or portfolio_missing or trade_log_missing:
+        # Reset cash if any of the data files were missing or the cash file is
+        # empty so that a new starting balance can be provided.
         open(cash_file, 'w').close()
 
     if st is not None:


### PR DESCRIPTION
## Summary
- `ensure_user_files` now treats an empty cash file as missing, clearing it so the user is prompted for a new starting balance

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_6894026611588324b814b182bd21c585