### PR TITLE
Fix cash prompt after clearing data

### DIFF
--- a/portfolio_app/app.py
+++ b/portfolio_app/app.py
@@ -107,9 +107,16 @@ def get_user_files(user_id: int) -> Tuple[str, str, str, str]:
 
 
 def user_needs_cash(user_id: int) -> bool:
-    """Return True if the user's cash file is missing or empty."""
+    """Return True if the user's cash file is missing or empty.
 
-    _, _, _, cash_file = get_user_files(user_id)
+    Also recreate the user's data files if they were deleted while the user
+    remained logged in. This ensures that clearing the portfolio or trade log
+    during a session will prompt for a new starting cash balance on the next
+    page load.
+    """
+
+    username, _, _, _ = get_user_files(user_id)
+    _, _, cash_file = ensure_user_files(username)
     return not (os.path.exists(cash_file) and os.path.getsize(cash_file) > 0)
 
 


### PR DESCRIPTION
## Summary
- Ensure users are prompted for starting cash again if their portfolio or trade log files are deleted during an active session by recreating missing data files and resetting cash.

## Testing
- `python -m py_compile portfolio_app/app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68940d74170483249b52b12d4308e94e