### PR TITLE
Restrict starting cash input to 10k

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Visualization tools — Matplotlib graphs comparing ChatGPT vs Index
 
 Logs & trade data — Auto-saved logs for transparency
 
-Starting balance prompt — Users without a recorded cash balance are asked to set one (up to $100k)
+Starting balance prompt — Users without a recorded cash balance are asked to set one (up to $10k)
 
 # Why This Matters
 AI is being hyped across every industry, but can it really manage money without guidance?

--- a/portfolio_app/app.py
+++ b/portfolio_app/app.py
@@ -344,15 +344,15 @@ def api_needs_cash(user_id):
 @app.route('/api/set-cash', methods=['POST'])
 @token_required
 def api_set_cash(user_id):
-    """Persist a starting cash balance for a user (up to 100k)."""
+    """Persist a starting cash balance for a user (up to 10k)."""
 
     data = request.get_json() or {}
     try:
         amount = float(data.get('cash', 0))
     except (TypeError, ValueError):
         return jsonify({'message': 'Invalid cash amount'}), 400
-    if amount < 0 or amount >= 100_000:
-        return jsonify({'message': 'Cash must be between 0 and 100000'}), 400
+    if amount < 0 or amount > 10_000:
+        return jsonify({'message': 'Cash must be between 0 and 10000'}), 400
 
     _, _, _, cash_file = get_user_files(user_id)
     with open(cash_file, 'w') as f:

--- a/portfolio_app/script.js
+++ b/portfolio_app/script.js
@@ -37,10 +37,15 @@ document.addEventListener('DOMContentLoaded', () => {
             if (data.needs_cash) {
                 let amount;
                 do {
-                    amount = prompt('Enter starting cash (max 100000):');
-                    if (amount === null) return; // user cancelled
-                    amount = parseFloat(amount);
-                } while (isNaN(amount) || amount < 0 || amount > 100000);
+                    const input = prompt('Enter starting cash (0-10000):');
+                    if (input === null) return; // user cancelled
+                    const trimmed = input.trim();
+                    if (/^\d+(\.\d+)?$/.test(trimmed)) {
+                        amount = Number(trimmed);
+                    } else {
+                        amount = NaN;
+                    }
+                } while (!Number.isFinite(amount) || amount < 0 || amount > 10000);
 
                 const setRes = await fetch('/api/set-cash', {
                     method: 'POST',


### PR DESCRIPTION
## Summary
- enforce numeric-only starting cash prompt and cap at $10k on the client
- validate and persist starting cash up to $10k on the server
- update documentation to reflect new $10k starting cash limit

## Testing
- `python -m py_compile portfolio_app/app.py`
- `node --check portfolio_app/script.js`


------
https://chatgpt.com/codex/tasks/task_e_6894aa1e964883248028982582b8643e