### PR TITLE
Add cash and deployed capital to portfolio dashboard

### DIFF
--- a/portfolio_app/index.html
+++ b/portfolio_app/index.html
@@ -36,6 +36,14 @@
                     <p id="totalEquity">--</p>
                 </div>
                 <div class="card">
+                    <h3>Cash Balance</h3>
+                    <p id="cashBalance">--</p>
+                </div>
+                <div class="card">
+                    <h3>Deployed Capital</h3>
+                    <p id="deployedCapital">--</p>
+                </div>
+                <div class="card">
                     <h3>Number of Trades</h3>
                     <p id="numTrades">0</p>
                 </div>

--- a/portfolio_app/sample_portfolio.js
+++ b/portfolio_app/sample_portfolio.js
@@ -19,6 +19,12 @@ document.addEventListener('DOMContentLoaded', () => {
             if (data.total_equity) {
                 document.getElementById('totalEquity').textContent = `$${data.total_equity}`;
             }
+            if (data.cash) {
+                document.getElementById('cashBalance').textContent = `$${data.cash}`;
+            }
+            if (data.deployed_capital) {
+                document.getElementById('deployedCapital').textContent = `$${data.deployed_capital}`;
+            }
         } catch (err) {
             console.error(err);
             const el = document.getElementById('errorMessage');

--- a/portfolio_app/script.js
+++ b/portfolio_app/script.js
@@ -85,6 +85,12 @@ document.addEventListener('DOMContentLoaded', () => {
             if (data.total_equity) {
                 document.getElementById('totalEquity').textContent = `$${data.total_equity}`;
             }
+            if (data.cash) {
+                document.getElementById('cashBalance').textContent = `$${data.cash}`;
+            }
+            if (data.deployed_capital) {
+                document.getElementById('deployedCapital').textContent = `$${data.deployed_capital}`;
+            }
             return data.positions.length > 0;
         } catch (err) {
             showError('Failed to load portfolio', err);

--- a/portfolio_app/templates/sample_portfolio.html
+++ b/portfolio_app/templates/sample_portfolio.html
@@ -27,6 +27,14 @@
                     <h3>Current Total Equity</h3>
                     <p id="totalEquity">--</p>
                 </div>
+                <div class="card">
+                    <h3>Cash Balance</h3>
+                    <p id="cashBalance">--</p>
+                </div>
+                <div class="card">
+                    <h3>Deployed Capital</h3>
+                    <p id="deployedCapital">--</p>
+                </div>
             </div>
         </section>
         <section id="graphs">


### PR DESCRIPTION
## Summary
- Return cash balance and deployed capital from portfolio APIs alongside total equity.
- Show cash and deployed capital in dashboard and sample portfolio pages.

## Testing
- `python -m py_compile portfolio_app/app.py && echo "py_compile success"`


------
https://chatgpt.com/codex/tasks/task_e_6894acecb28c8324b6916e5e03a2c89d