### PR TITLE
Show percent change from starting capital next to total equity

### DIFF
--- a/portfolio_app/index.html
+++ b/portfolio_app/index.html
@@ -33,7 +33,7 @@
             <div class="summary-cards">
                 <div class="card">
                     <h3>Current Total Equity</h3>
-                    <p id="totalEquity">--</p>
+                    <p><span id="totalEquity">--</span> <span id="equityChange"></span></p>
                 </div>
                 <div class="card">
                     <h3>Cash Balance</h3>

--- a/portfolio_app/sample_portfolio.js
+++ b/portfolio_app/sample_portfolio.js
@@ -18,6 +18,10 @@ document.addEventListener('DOMContentLoaded', () => {
             });
             if (data.total_equity) {
                 document.getElementById('totalEquity').textContent = `$${data.total_equity}`;
+                if (data.starting_capital) {
+                    const change = ((parseFloat(data.total_equity) - parseFloat(data.starting_capital)) / parseFloat(data.starting_capital)) * 100;
+                    document.getElementById('equityChange').textContent = `(${change.toFixed(2)}%)`;
+                }
             }
             if (data.cash) {
                 document.getElementById('cashBalance').textContent = `$${data.cash}`;

--- a/portfolio_app/script.js
+++ b/portfolio_app/script.js
@@ -84,6 +84,10 @@ document.addEventListener('DOMContentLoaded', () => {
             });
             if (data.total_equity) {
                 document.getElementById('totalEquity').textContent = `$${data.total_equity}`;
+                if (data.starting_capital) {
+                    const change = ((parseFloat(data.total_equity) - parseFloat(data.starting_capital)) / parseFloat(data.starting_capital)) * 100;
+                    document.getElementById('equityChange').textContent = `(${change.toFixed(2)}%)`;
+                }
             }
             if (data.cash) {
                 document.getElementById('cashBalance').textContent = `$${data.cash}`;

--- a/portfolio_app/templates/sample_portfolio.html
+++ b/portfolio_app/templates/sample_portfolio.html
@@ -25,7 +25,7 @@
             <div class="summary-cards">
                 <div class="card">
                     <h3>Current Total Equity</h3>
-                    <p id="totalEquity">--</p>
+                    <p><span id="totalEquity">--</span> <span id="equityChange"></span></p>
                 </div>
                 <div class="card">
                     <h3>Cash Balance</h3>


### PR DESCRIPTION
## Summary
- Display starting-capital percent change beside current total equity on dashboard and sample portfolio pages.
- Expose `starting_capital` in `/api/portfolio` and `/api/sample-portfolio` by parsing the first TOTAL row in portfolio data.
- Compute percent change on the client side and render it adjacent to total equity.

## Testing
- `python -m py_compile portfolio_app/app.py`
- `node --check portfolio_app/script.js`
- `node --check portfolio_app/sample_portfolio.js`


------
https://chatgpt.com/codex/tasks/task_e_6894cc3df4a08324bae2f455c30bd176