### PR TITLE
Fix equity percent change calculation

### DIFF
--- a/portfolio_app/sample_portfolio.js
+++ b/portfolio_app/sample_portfolio.js
@@ -19,8 +19,14 @@ document.addEventListener('DOMContentLoaded', () => {
             if (data.total_equity) {
                 document.getElementById('totalEquity').textContent = `$${data.total_equity}`;
                 if (data.starting_capital) {
-                    const change = ((parseFloat(data.total_equity) - parseFloat(data.starting_capital)) / parseFloat(data.starting_capital)) * 100;
-                    document.getElementById('equityChange').textContent = `(${change.toFixed(2)}%)`;
+                    const total = parseFloat(String(data.total_equity).replace(/,/g, ''));
+                    const start = parseFloat(String(data.starting_capital).replace(/,/g, ''));
+                    if (!isNaN(total) && !isNaN(start) && start !== 0) {
+                        const change = ((total - start) / start) * 100;
+                        document.getElementById('equityChange').textContent = `(${change.toFixed(2)}%)`;
+                    } else {
+                        document.getElementById('equityChange').textContent = '';
+                    }
                 }
             }
             if (data.cash) {

--- a/portfolio_app/script.js
+++ b/portfolio_app/script.js
@@ -85,8 +85,14 @@ document.addEventListener('DOMContentLoaded', () => {
             if (data.total_equity) {
                 document.getElementById('totalEquity').textContent = `$${data.total_equity}`;
                 if (data.starting_capital) {
-                    const change = ((parseFloat(data.total_equity) - parseFloat(data.starting_capital)) / parseFloat(data.starting_capital)) * 100;
-                    document.getElementById('equityChange').textContent = `(${change.toFixed(2)}%)`;
+                    const total = parseFloat(String(data.total_equity).replace(/,/g, ''));
+                    const start = parseFloat(String(data.starting_capital).replace(/,/g, ''));
+                    if (!isNaN(total) && !isNaN(start) && start !== 0) {
+                        const change = ((total - start) / start) * 100;
+                        document.getElementById('equityChange').textContent = `(${change.toFixed(2)}%)`;
+                    } else {
+                        document.getElementById('equityChange').textContent = '';
+                    }
                 }
             }
             if (data.cash) {


### PR DESCRIPTION
## Summary
- handle commas and invalid values when calculating total-equity percent change
- clear percent change display when calculation is invalid

## Testing
- `node --check script.js`
- `node --check sample_portfolio.js`
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_6894cedcdf3c83248b8256dc48dd1610