### PR TITLE
Add user-specific equity chart on dashboard

### DIFF
--- a/portfolio_app/index.html
+++ b/portfolio_app/index.html
@@ -56,6 +56,7 @@
 
         <section id="graphs">
             <h2>Portfolio vs Benchmark</h2>
+            <img id="equityChart" alt="Equity history chart" />
         </section>
 
         <section id="portfolio">

--- a/portfolio_app/script.js
+++ b/portfolio_app/script.js
@@ -25,6 +25,7 @@ document.addEventListener('DOMContentLoaded', () => {
         await checkStartingCash();
         await loadPortfolio();
         loadTradeLog();
+        loadEquityChart();
     }
 
     async function checkStartingCash() {
@@ -140,6 +141,21 @@ document.addEventListener('DOMContentLoaded', () => {
         } catch (err) {
             showError('Failed to load trade log', err);
             return false;
+        }
+    }
+
+    async function loadEquityChart() {
+        const chart = document.getElementById('equityChart');
+        if (!chart) return;
+        try {
+            const res = await fetch('/api/equity-chart.png', {
+                headers: { Authorization: `Bearer ${token}` }
+            });
+            if (!res.ok) throw new Error('Failed to load equity chart');
+            const blob = await res.blob();
+            chart.src = URL.createObjectURL(blob);
+        } catch (err) {
+            showError('Failed to load equity chart', err);
         }
     }
 


### PR DESCRIPTION
## Summary
- Render user's portfolio vs S&P 500 chart as PNG via new /api/equity-chart.png endpoint
- Embed chart in dashboard between Portfolio vs Benchmark and Portfolio sections
- Load chart using client-side script with Authorization token

## Testing
- `pytest`
- `python -m py_compile portfolio_app/app.py`


------
https://chatgpt.com/codex/tasks/task_e_6894e0042a58832487cc9a27fed52ad5