### PR TITLE
Handle missing benchmark data for chart and refresh chart after updates

### DIFF
--- a/portfolio_app/app.py
+++ b/portfolio_app/app.py
@@ -327,9 +327,32 @@ def user_chart_png(user_id):
 
     chatgpt_totals = generate_graph.load_portfolio_details(baseline_equity, None, None)
 
-    sp500 = generate_graph.download_sp500(chatgpt_totals['Date'], baseline_equity)
-    if sp500.empty:
-        return jsonify({'message': 'No benchmark data'}), 404
+    try:
+        sp500 = generate_graph.download_sp500(chatgpt_totals['Date'], baseline_equity)
+        if sp500.empty:
+            raise ValueError('No benchmark data')
+    except Exception:
+        plt.style.use('seaborn-v0_8-whitegrid')
+        fig, ax = plt.subplots(figsize=(10, 6))
+        ax.plot(
+            chatgpt_totals['Date'],
+            chatgpt_totals['Total Equity'],
+            label=f'{username} (${baseline_equity:.0f} Invested)',
+            marker='o',
+            color='blue',
+            linewidth=2,
+        )
+        ax.set_title('Portfolio Performance')
+        ax.set_xlabel('Date')
+        ax.set_ylabel(f'Value of ${baseline_equity:.0f} Investment')
+        ax.legend()
+        ax.grid(True)
+        fig.autofmt_xdate()
+        buf = BytesIO()
+        fig.savefig(buf, format='png', bbox_inches='tight')
+        plt.close(fig)
+        buf.seek(0)
+        return send_file(buf, mimetype='image/png')
 
     plt.style.use('seaborn-v0_8-whitegrid')
     fig, ax = plt.subplots(figsize=(10, 6))

--- a/portfolio_app/script.js
+++ b/portfolio_app/script.js
@@ -205,6 +205,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 tradeForm.reset();
                 await loadPortfolio();
                 await loadTradeLog();
+                await loadEquityChart();
             } catch (err) {
                 showError('Trade failed', err, 'tradeErrorMessage');
             }
@@ -222,6 +223,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 if (!res.ok) throw new Error('Failed to process portfolio');
                 alert('Portfolio processed successfully');
                 await loadPortfolio();
+                await loadEquityChart();
             } catch (err) {
                 showError('Failed to process portfolio', err);
             }


### PR DESCRIPTION
## Summary
- Reload equity chart after trades and portfolio processing so visuals stay current
- Render portfolio chart even when S&P 500 data cannot be retrieved

## Testing
- `pytest`
- `python -m py_compile portfolio_app/app.py`

------
https://chatgpt.com/codex/tasks/task_e_6894ed7ba4a88324bb0e0fe59d01d4cb