### PR TITLE
Handle missing S&P 500 data in portfolio charts

### DIFF
--- a/portfolio_app/Scripts and CSV Files/Generate_Graph.py
+++ b/portfolio_app/Scripts and CSV Files/Generate_Graph.py
@@ -84,6 +84,10 @@ def download_sp500(dates: pd.Series, baseline_equity: float = 100.0) -> pd.DataF
     )["Close"]
 
     aligned = sp500.reindex(pd.to_datetime(dates)).ffill().bfill()
+    if aligned.isna().all():
+        raise ValueError("SPX has no data after alignment")
+    if aligned.isna().any():
+        print("Warning: SPX has NaNs after alignment")
 
     base_price = aligned.iloc[0]
     values = aligned / base_price * baseline_equity
@@ -101,6 +105,8 @@ def main(
     chatgpt_totals = load_portfolio_details(start_date, end_date)
     baseline_equity = float(chatgpt_totals["Total Equity"].iloc[0])
     sp500 = download_sp500(chatgpt_totals["Date"], baseline_equity)
+    if sp500["SPX Value"].isna().all():
+        raise ValueError("S&P 500 data is empty after alignment")
 
     plt.style.use("seaborn-v0_8-whitegrid")
     fig, ax = plt.subplots(figsize=(10, 6))

--- a/portfolio_app/app.py
+++ b/portfolio_app/app.py
@@ -252,7 +252,7 @@ def sample_chart_png():
     fallback = Path(__file__).resolve().parent / 'week4_performance.png'
     try:
         sp500 = generate_graph.download_sp500(chatgpt_totals['Date'], baseline_equity)
-        if sp500.empty:
+        if sp500['SPX Value'].isna().all():
             raise ValueError('Empty SP500 data')
     except Exception:
         # Fall back to a pre-generated chart so the sample page always works
@@ -334,7 +334,7 @@ def user_chart_png(user_id):
 
     try:
         sp500 = generate_graph.download_sp500(chatgpt_totals['Date'], baseline_equity)
-        if sp500.empty:
+        if sp500['SPX Value'].isna().all():
             raise ValueError('No benchmark data')
     except Exception:
         plt.style.use('seaborn-v0_8-whitegrid')


### PR DESCRIPTION
## Summary
- Validate and align S&P 500 data with portfolio dates, warning on NaNs and aborting when no benchmark data is available.
- Guard Flask chart routes against empty S&P 500 values so graphs fail fast instead of rendering incomplete data.

## Testing
- `python -m py_compile "portfolio_app/Scripts and CSV Files/Generate_Graph.py" portfolio_app/app.py`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`

------
https://chatgpt.com/codex/tasks/task_e_6896149c327083248cdef158ff4f362c