### PR TITLE
Handle missing portfolio data for equity chart

### DIFF
--- a/portfolio_app/app.py
+++ b/portfolio_app/app.py
@@ -328,7 +328,14 @@ def user_chart_png(user_id):
 
     generate_graph.PORTFOLIO_CSV = Path(portfolio_csv)
 
-    chatgpt_totals = generate_graph.load_portfolio_details(None, None)
+    try:
+        chatgpt_totals = generate_graph.load_portfolio_details(None, None)
+    except SystemExit:
+        return jsonify({'message': 'No portfolio data available to plot'}), 400
+
+    if chatgpt_totals.empty:
+        return jsonify({'message': 'No portfolio data available to plot'}), 400
+
     if baseline_equity is None:
         baseline_equity = float(chatgpt_totals['Total Equity'].iloc[0])
 

--- a/portfolio_app/script.js
+++ b/portfolio_app/script.js
@@ -151,11 +151,26 @@ document.addEventListener('DOMContentLoaded', () => {
             const res = await fetch('/api/equity-chart.png', {
                 headers: { Authorization: `Bearer ${token}` }
             });
-            if (!res.ok) throw new Error('Failed to load equity chart');
+            if (!res.ok) {
+                let msg = 'Failed to load equity chart';
+                try {
+                    const errData = await res.json();
+                    if (errData && errData.message) {
+                        msg = errData.message;
+                    }
+                } catch (_) {
+                    try {
+                        msg = await res.text();
+                    } catch (_) {
+                        /* ignore */
+                    }
+                }
+                throw new Error(msg);
+            }
             const blob = await res.blob();
             chart.src = URL.createObjectURL(blob);
         } catch (err) {
-            showError('Failed to load equity chart', err);
+            showError(err.message || 'Failed to load equity chart', err);
         }
     }
 


### PR DESCRIPTION
## Summary
- return a friendly error if the equity chart lacks portfolio data
- surface server error messages when loading the equity chart on the client

## Testing
- `python -m py_compile app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6896187827b88324a06e06c4610a5dbe