### PR TITLE
Validate stop-loss input on the client

### DIFF
--- a/portfolio_app/script.js
+++ b/portfolio_app/script.js
@@ -189,6 +189,18 @@ document.addEventListener('DOMContentLoaded', () => {
             };
             const stopLossInput = document.getElementById('trade-stop-loss').value.trim();
             if (stopLossInput) {
+                let valid = false;
+                if (stopLossInput.endsWith('%')) {
+                    const val = parseFloat(stopLossInput.slice(0, -1));
+                    if (!isNaN(val) && val >= 0) valid = true;
+                } else {
+                    const val = parseFloat(stopLossInput);
+                    if (!isNaN(val) && val >= 0) valid = true;
+                }
+                if (!valid) {
+                    showError('Invalid stop loss value', undefined, 'tradeErrorMessage');
+                    return;
+                }
                 payload.stop_loss = stopLossInput;
             }
             try {


### PR DESCRIPTION
## Summary
- Validate trade form stop-loss input on the client.
- Show an 'Invalid stop loss value' message where other trade errors appear.

## Testing
- `node --check portfolio_app/script.js`
- `python -m py_compile portfolio_app/app.py portfolio_app/trading_script.py`

------
https://chatgpt.com/codex/tasks/task_e_68962b63b9648324968cd160dfb666af