### PR TITLE
Validate stop loss price before submitting trade

### DIFF
--- a/portfolio_app/index.html
+++ b/portfolio_app/index.html
@@ -82,7 +82,6 @@
 
         <section id="trade-form">
             <h2>Place Trade</h2>
-            <div id="tradeErrorMessage" class="visually-hidden" role="alert" aria-live="polite"></div>
             <form id="tradeForm">
                 <label class="visually-hidden" for="trade-ticker">Ticker</label>
                 <input type="text" id="trade-ticker" placeholder="Ticker" required>
@@ -101,6 +100,7 @@
 
                 <label class="visually-hidden" for="trade-stop-loss">Stop Loss (optional)</label>
                 <input type="text" id="trade-stop-loss" placeholder="Stop Loss (Buys only)">
+                <div id="tradeErrorMessage" class="visually-hidden" role="alert" aria-live="polite"></div>
 
                 <label class="visually-hidden" for="trade-reason">Reason (optional)</label>
                 <input type="text" id="trade-reason" placeholder="Reason (optional)">

--- a/portfolio_app/script.js
+++ b/portfolio_app/script.js
@@ -188,10 +188,7 @@ document.addEventListener('DOMContentLoaded', () => {
                 reason: document.getElementById('trade-reason').value.trim(),
             };
             const stopLossInput = document.getElementById('trade-stop-loss').value.trim();
-            if (stopLossInput >= price){
-                showError('Invalid stop loss value', undefined, 'tradeErrorMessage');
-                    return;
-            }
+            const price = payload.price;
             if (stopLossInput) {
                 let valid = false;
                 if (stopLossInput.endsWith('%')) {
@@ -199,7 +196,13 @@ document.addEventListener('DOMContentLoaded', () => {
                     if (!isNaN(val) && val >= 0) valid = true;
                 } else {
                     const val = parseFloat(stopLossInput);
-                    if (!isNaN(val) && val >= 0) valid = true;
+                    if (!isNaN(val) && val >= 0) {
+                        if (val >= price) {
+                            showError('Stop loss must be below price', undefined, 'tradeErrorMessage');
+                            return;
+                        }
+                        valid = true;
+                    }
                 }
                 if (!valid) {
                     showError('Invalid stop loss value', undefined, 'tradeErrorMessage');


### PR DESCRIPTION
## Summary
- move trade error message inside trade form so users see validation feedback next to the stop loss field
- validate stop loss input against trade price and display an error if the stop loss is greater than or equal to the price

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68964e4750b0832491f2ba465ee61904