### PR TITLE
Move trade error message below submit button

### DIFF
--- a/portfolio_app/index.html
+++ b/portfolio_app/index.html
@@ -100,13 +100,13 @@
 
                 <label class="visually-hidden" for="trade-stop-loss">Stop Loss (optional)</label>
                 <input type="text" id="trade-stop-loss" placeholder="Stop Loss (Buys only)">
-                <span id="tradeErrorMessage" class="visually-hidden" role="alert" aria-live="polite"></span>
 
                 <label class="visually-hidden" for="trade-reason">Reason (optional)</label>
                 <input type="text" id="trade-reason" placeholder="Reason (optional)">
 
                 <button type="submit">Submit Trade</button>
             </form>
+            <span id="tradeErrorMessage" class="visually-hidden" role="alert" aria-live="polite"></span>
         </section>
 
         <section id="trade-log">


### PR DESCRIPTION
## Summary
- Relocate trade error message element to appear after the trade form and before the trade log

## Testing
- `python -m py_compile $(git ls-files '*.py' -z | xargs -0)`

------
https://chatgpt.com/codex/tasks/task_e_68965453fe8083248be0ecad24273443