### PR TITLE
feat: add password visibility toggle

### DIFF
--- a/portfolio_app/login.css
+++ b/portfolio_app/login.css
@@ -49,6 +49,20 @@ body {
     background: transparent;
 }
 
+.input-group .toggle-password {
+    background: transparent;
+    border: none;
+    color: #764ba2;
+    cursor: pointer;
+    padding: 0;
+    margin: 0 0 0 5px;
+    width: auto;
+}
+
+.input-group .toggle-password:hover {
+    background: transparent;
+}
+
 button {
     width: 100%;
     padding: 10px;

--- a/portfolio_app/templates/login.html
+++ b/portfolio_app/templates/login.html
@@ -22,6 +22,7 @@
             <i class="fas fa-lock"></i>
             <label class="visually-hidden" for="login-password">Password</label>
             <input type="password" id="login-password" placeholder="Password" required>
+            <button type="button" id="login-toggle-password" class="toggle-password" aria-label="Show password"><i class="fas fa-eye"></i></button>
         </div>
         <button type="submit">Login</button>
         <p id="error" class="error-message" role="alert"></p>
@@ -29,6 +30,14 @@
     <p><a href="/sample-portfolio">View Sample Portfolio</a></p>
 </div>
 <script>
+const loginPassword = document.getElementById('login-password');
+const loginToggle = document.getElementById('login-toggle-password');
+loginToggle.addEventListener('click', () => {
+    const type = loginPassword.getAttribute('type') === 'password' ? 'text' : 'password';
+    loginPassword.setAttribute('type', type);
+    loginToggle.innerHTML = type === 'password' ? '<i class="fas fa-eye"></i>' : '<i class="fas fa-eye-slash"></i>';
+});
+
 document.getElementById('login-form').addEventListener('submit', async e => {
     e.preventDefault();
     const errorEl = document.getElementById('error');

--- a/portfolio_app/templates/signin.html
+++ b/portfolio_app/templates/signin.html
@@ -27,12 +27,21 @@
             <i class="fas fa-lock"></i>
             <label class="visually-hidden" for="signup-password">Password</label>
             <input type="password" id="signup-password" placeholder="Password" required>
+            <button type="button" id="signup-toggle-password" class="toggle-password" aria-label="Show password"><i class="fas fa-eye"></i></button>
         </div>
         <button type="submit">Sign Up</button>
         <p id="signup-error" class="error-message" role="alert"></p>
     </form>
 </div>
 <script>
+const signupPassword = document.getElementById('signup-password');
+const signupToggle = document.getElementById('signup-toggle-password');
+signupToggle.addEventListener('click', () => {
+    const type = signupPassword.getAttribute('type') === 'password' ? 'text' : 'password';
+    signupPassword.setAttribute('type', type);
+    signupToggle.innerHTML = type === 'password' ? '<i class="fas fa-eye"></i>' : '<i class="fas fa-eye-slash"></i>';
+});
+
 document.getElementById('signup-form').addEventListener('submit', async e => {
     e.preventDefault();
     const errorEl = document.getElementById('signup-error');


### PR DESCRIPTION
## Summary
- add show/hide password toggle on login page
- add show/hide password toggle on sign-up page
- style password toggle button

## Testing
- `pytest`
- `find . -name '*.py' -print0 | xargs -0 python -m py_compile`


------
https://chatgpt.com/codex/tasks/task_e_68965c2b5f44832499236b38d8381bc2