### PR TITLE
Add about page and navigation link

### DIFF
--- a/portfolio_app/about.html
+++ b/portfolio_app/about.html
@@ -1,0 +1,49 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>About - ChatGPT Micro-Cap Experiment</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Poppins:wght@300;400;600&display=swap" rel="stylesheet">
+    <link rel="stylesheet" href="/styles.css" />
+</head>
+<body>
+    <header>
+        <h1>About This Project</h1>
+        <nav>
+            <ul class="nav-links">
+                <li><a href="/dashboard#home">Home</a></li>
+                <li><a href="/dashboard#portfolio">Portfolio</a></li>
+                <li><a href="/dashboard#trade-log">Trade Log</a></li>
+                <li><a href="/dashboard#graphs">Graphs</a></li>
+                <li><a href="/about">About</a></li>
+                <li><a href="https://github.com/LuckyOne7777/ChatGPT-Micro-Cap-Experiment" target="_blank" rel="noopener noreferrer">GitHub</a></li>
+                <li><a href="https://nathanbsmith729.substack.com" target="_blank" rel="noopener noreferrer">Blog</a></li>
+                <li><a href="/login">Login</a></li>
+                <li><a href="/signin">Sign Up</a></li>
+            </ul>
+        </nav>
+    </header>
+    <main>
+        <section>
+            <h2>About the ChatGPT Micro-Cap Experiment</h2>
+            <p>This project showcases an AI-managed micro-cap trading portfolio. It provides tools for tracking holdings, logging trades, and visualizing performance.</p>
+        </section>
+        <section>
+            <h2>Using the Tools</h2>
+            <ul>
+                <li><strong>Process Portfolio</strong>: Updates positions with current market prices and recalculates equity.</li>
+                <li><strong>Trade Form</strong>: Submit buys or sells by entering ticker, price, shares, and optional stop loss or reason.</li>
+                <li><strong>Trade Log</strong>: Review a history of all recorded trades for transparency and analysis.</li>
+                <li><strong>Graphs</strong>: View equity history versus benchmarks to measure performance over time.</li>
+            </ul>
+            <p>For more background and research notes, see the <a href="https://github.com/LuckyOne7777/ChatGPT-Micro-Cap-Experiment" target="_blank" rel="noopener noreferrer">GitHub repository</a>.</p>
+        </section>
+    </main>
+    <footer>
+        <p>&copy; 2024 ChatGPT Micro-Cap Experiment. All rights reserved.</p>
+    </footer>
+</body>
+</html>

--- a/portfolio_app/app.py
+++ b/portfolio_app/app.py
@@ -194,6 +194,11 @@ def serve_dashboard():
     return send_from_directory('.', 'index.html')
 
 
+@app.route('/about')
+def serve_about():
+    return send_from_directory('.', 'about.html')
+
+
 @app.route('/script.js')
 def serve_script():
     return send_from_directory('.', 'script.js')

--- a/portfolio_app/index.html
+++ b/portfolio_app/index.html
@@ -18,7 +18,7 @@
                 <li><a href="#portfolio">Portfolio</a></li>
                 <li><a href="#trade-log">Trade Log</a></li>
                 <li><a href="#graphs">Graphs</a></li>
-                <li><a href="#about">About</a></li>
+                <li><a href="/about">About</a></li>
                 <li><a href="https://github.com/LuckyOne7777/ChatGPT-Micro-Cap-Experiment" target="_blank" rel="noopener noreferrer">GitHub</a></li>
                 <li><a href="https://nathanbsmith729.substack.com" target="_blank" rel="noopener noreferrer">Blog</a></li>
                 <li><a href="/login">Login</a></li>
@@ -127,12 +127,6 @@
                     <tbody id="tradeLogBody"></tbody>
                 </table>
             </div>
-        </section>
-        <section id="about">
-            <h2>About</h2>
-            <p>The ChatGPT Micro-Cap Experiment is an AI-managed portfolio exploring strategies
-            in the micro-cap stock space.</p>
-            <a class="github-button" href="https://github.com" target="_blank" rel="noopener noreferrer">View on GitHub</a>
         </section>
     </main>
 


### PR DESCRIPTION
## Summary
- Add dedicated `about.html` page documenting how to use portfolio tools
- Link dashboard navigation to new about page and drop inline about section
- Serve about page via new `/about` Flask route

## Testing
- `python -m py_compile portfolio_app/app.py`


------
https://chatgpt.com/codex/tasks/task_e_68966aeb01d08324ab20185bb36f2a8a