### PR TITLE
Serve home and auth pages

### DIFF
--- a/portfolio_app/app.py
+++ b/portfolio_app/app.py
@@ -8,7 +8,7 @@ import sqlite3
 
 import jwt
 import pandas as pd
-from flask import Flask, jsonify, request
+from flask import Flask, jsonify, request, render_template
 from flask_bcrypt import Bcrypt
 
 import trading_script as ts
@@ -23,7 +23,7 @@ from repo import (
     get_position,
 )
 
-app = Flask(__name__)
+app = Flask(__name__, static_folder=".", static_url_path="")
 app.config["SECRET_KEY"] = os.getenv("SECRET_KEY", "change-this-secret")
 bcrypt = Bcrypt(app)
 
@@ -39,6 +39,27 @@ def init_db() -> None:
         conn.commit()
 
 init_db()
+
+
+@app.route("/")
+def home() -> str:
+    return render_template("home.html")
+
+
+@app.route("/login")
+def login_page() -> str:
+    return render_template("login.html")
+
+
+@app.route("/signin")
+def signin_page() -> str:
+    return render_template("signin.html")
+
+
+@app.route("/sample-portfolio")
+def sample_portfolio() -> str:
+    return render_template("sample_portfolio.html")
+
 
 def token_required(f):
     @wraps(f)

--- a/portfolio_app/templates/login.html
+++ b/portfolio_app/templates/login.html
@@ -43,11 +43,11 @@ document.getElementById('login-form').addEventListener('submit', async e => {
     const errorEl = document.getElementById('error');
     errorEl.textContent = '';
     try {
-        const res = await fetch('/login', {
+        const res = await fetch('/api/login', {
             method: 'POST',
             headers: {'Content-Type': 'application/json'},
             body: JSON.stringify({
-                identifier: document.getElementById('login-identifier').value,
+                username: document.getElementById('login-identifier').value,
                 password: document.getElementById('login-password').value
             })
         });

--- a/portfolio_app/templates/signin.html
+++ b/portfolio_app/templates/signin.html
@@ -47,7 +47,7 @@ document.getElementById('signup-form').addEventListener('submit', async e => {
     const errorEl = document.getElementById('signup-error');
     errorEl.textContent = '';
     try {
-        const res = await fetch('/register', {
+        const res = await fetch('/api/register', {
             method: 'POST',
             headers: {'Content-Type': 'application/json'},
             body: JSON.stringify({


### PR DESCRIPTION
## Summary
- Configure Flask app to serve home, login, sign-up, and sample portfolio pages
- Align login and registration forms with `/api/login` and `/api/register`

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689778da4964832496e15edeeeef9a9b