### PR TITLE
Add dashboard and about routes

### DIFF
--- a/portfolio_app/app.py
+++ b/portfolio_app/app.py
@@ -61,6 +61,18 @@ def sample_portfolio() -> str:
     return render_template("sample_portfolio.html")
 
 
+@app.route("/dashboard")
+def dashboard_page() -> str:
+    """Serve the main dashboard page."""
+    return app.send_static_file("index.html")
+
+
+@app.route("/about")
+def about_page() -> str:
+    """Serve the about page."""
+    return app.send_static_file("about.html")
+
+
 def token_required(f):
     @wraps(f)
     def decorated(*args, **kwargs):


### PR DESCRIPTION
## Summary
- serve the dashboard at `/dashboard`
- expose the static about page at `/about`

## Testing
- `pytest`
- `python -m py_compile portfolio_app/app.py`
- `pip install --quiet sqlalchemy` *(failed: Cannot connect to proxy)*

------
https://chatgpt.com/codex/tasks/task_e_68977b70cd708324978591e03cc47d7f