### PR TITLE
Fix manual trade validation and update portfolio

### DIFF
--- a/portfolio_app/requirements.txt
+++ b/portfolio_app/requirements.txt
@@ -6,3 +6,4 @@ Flask==3.0.2
 Flask-Bcrypt==1.0.1
 PyJWT==2.8.0
 mpld3>=0.5.9
+SQLAlchemy==2.0.30


### PR DESCRIPTION
## Summary
- raise errors when manual trades fail so API can report problems and tables stay in sync
- catch trade errors in `api/trade` and in `process_portfolio`
- add missing SQLAlchemy dependency

## Testing
- `python -m py_compile portfolio_app/app.py portfolio_app/trading_script.py`
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6897830f37e48324b57908e6ae9ea2bc