### PR TITLE
Initialize DB tables for equity graph logging

### DIFF
--- a/portfolio_app/app.py
+++ b/portfolio_app/app.py
@@ -24,6 +24,7 @@ from repo import (
     get_equity_series,
     get_position,
 )
+from db import init_db as init_models
 
 app = Flask(__name__, static_folder=".", static_url_path="")
 app.config["SECRET_KEY"] = os.getenv("SECRET_KEY", "change-this-secret")
@@ -41,6 +42,7 @@ def init_db() -> None:
         conn.commit()
 
 init_db()
+init_models()
 
 
 @app.route("/")


### PR DESCRIPTION
## Summary
- Ensure portfolio database tables are created on app startup so equity logging works

## Testing
- `python -m py_compile portfolio_app/app.py`

------
https://chatgpt.com/codex/tasks/task_e_68978747fab0832481c66ec4161d750e