### PR TITLE
Restrict portfolio processing to post-market hours

### DIFF
--- a/portfolio_app/models.py
+++ b/portfolio_app/models.py
@@ -3,7 +3,16 @@ from __future__ import annotations
 from datetime import datetime, date
 from decimal import Decimal
 
-from sqlalchemy import String, Numeric, Integer, Date, DateTime, Text, ForeignKey
+from sqlalchemy import (
+    String,
+    Numeric,
+    Integer,
+    Date,
+    DateTime,
+    Text,
+    ForeignKey,
+    UniqueConstraint,
+)
 from sqlalchemy.orm import Mapped, mapped_column
 
 from db import Base
@@ -39,8 +48,9 @@ class CashLedger(Base):
 
 class EquityHistory(Base):
     __tablename__ = "equity_history"
+    __table_args__ = (UniqueConstraint("date", name="uix_equity_history_date"),)
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
-    date: Mapped[date] = mapped_column(Date, unique=True)
+    date: Mapped[date] = mapped_column(Date)
     portfolio_equity: Mapped[Decimal] = mapped_column(Numeric(18, 6))
     benchmark_equity: Mapped[Decimal | None] = mapped_column(Numeric(18, 6), nullable=True)
 


### PR DESCRIPTION
## Summary
- Gate `/api/process-portfolio` so it only runs after 4:10 PM ET on valid U.S. trading days, unless `force: true` is supplied.
- Add U.S. market holiday calculations using `datetime`/`zoneinfo` and keep portfolio logic behind `process_portfolio(user_id)` wrapper.
- Enforce one-row-per-day in `equity_history` with a unique constraint and SQLite upsert.

## Testing
- `python -m py_compile portfolio_app/app.py portfolio_app/models.py portfolio_app/repo.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68978a5557b8832480643fba5e0e7baa