### PR TITLE
Add current price and PnL processing

### DIFF
--- a/portfolio_app/index.html
+++ b/portfolio_app/index.html
@@ -71,14 +71,21 @@
                         <tr>
                             <th>Ticker</th>
                             <th>Shares</th>
-                            <th>Cost Basis</th>
+                            <th>Buy Price</th>
                             <th>Current Price</th>
+                            <th>Position Value</th>
                             <th>PnL</th>
-                            <th>Stop Loss</th>
                         </tr>
                     </thead>
                     <tbody id="portfolioTableBody"></tbody>
                 </table>
+            </div>
+            <div id="portfolioTotals">
+                <p>Cash: <span id="totalsCash">--</span></p>
+                <p>Positions Value: <span id="totalsPositionsValue">--</span></p>
+                <p>PnL: <span id="totalsPnl">--</span></p>
+                <p>Total Equity: <span id="totalsTotalEquity">--</span></p>
+                <p id="asOfCaption"></p>
             </div>
         </section>
 

--- a/portfolio_app/models.py
+++ b/portfolio_app/models.py
@@ -12,6 +12,7 @@ from sqlalchemy import (
     Text,
     ForeignKey,
     UniqueConstraint,
+    Boolean,
 )
 from sqlalchemy.orm import Mapped, mapped_column
 
@@ -48,11 +49,16 @@ class CashLedger(Base):
 
 class EquityHistory(Base):
     __tablename__ = "equity_history"
-    __table_args__ = (UniqueConstraint("date", name="uix_equity_history_date"),)
+    __table_args__ = (
+        UniqueConstraint("user_id", "date", name="uix_equity_history_user_date"),
+    )
     id: Mapped[int] = mapped_column(Integer, primary_key=True)
+    user_id: Mapped[int] = mapped_column(Integer, index=True)
     date: Mapped[date] = mapped_column(Date)
     portfolio_equity: Mapped[Decimal] = mapped_column(Numeric(18, 6))
     benchmark_equity: Mapped[Decimal | None] = mapped_column(Numeric(18, 6), nullable=True)
+    process_type: Mapped[str] = mapped_column(String(10), default="regular")
+    is_final: Mapped[bool] = mapped_column(Boolean, default=True)
 
 class Setting(Base):
     __tablename__ = "settings"


### PR DESCRIPTION
## Summary
- compute close prices via yfinance with regular and force modes, returning fallback prices when needed
- calculate position values and PnL in /api/process-portfolio and upsert equity history per user
- update dashboard UI to show current price, position value, totals, and force processing caption

## Testing
- `python -m py_compile portfolio_app/app.py portfolio_app/repo.py portfolio_app/models.py`


------
https://chatgpt.com/codex/tasks/task_e_689793468d488324b0798db5c987ab7c