### PR TITLE
fix: ensure equity_history table includes new columns

### DIFF
--- a/portfolio_app/db.py
+++ b/portfolio_app/db.py
@@ -28,3 +28,25 @@ def init_db() -> None:
                         "CREATE UNIQUE INDEX uix_equity_history_user_date ON equity_history (user_id, date)"
                     )
                 )
+            if "process_type" not in columns:
+                conn.execute(
+                    text(
+                        "ALTER TABLE equity_history ADD COLUMN process_type VARCHAR(10) DEFAULT 'regular'"
+                    )
+                )
+                conn.execute(
+                    text(
+                        "UPDATE equity_history SET process_type = 'regular' WHERE process_type IS NULL"
+                    )
+                )
+            if "is_final" not in columns:
+                conn.execute(
+                    text(
+                        "ALTER TABLE equity_history ADD COLUMN is_final BOOLEAN DEFAULT 1"
+                    )
+                )
+                conn.execute(
+                    text(
+                        "UPDATE equity_history SET is_final = 1 WHERE is_final IS NULL"
+                    )
+                )


### PR DESCRIPTION
## Summary
- add migrations to create `process_type` and `is_final` columns in existing `equity_history` tables

## Testing
- `python -m pytest`
- `python -m py_compile portfolio_app/db.py`


------
https://chatgpt.com/codex/tasks/task_e_689799a9c794832483e58e6db15505f6