### PR TITLE
Ensure forced processing uses latest price

### DIFF
--- a/portfolio_app/trading_script.py
+++ b/portfolio_app/trading_script.py
@@ -187,9 +187,11 @@ def process_portfolio(
             if PORTFOLIO_CSV.exists():
                 try:
                     prev = pd.read_csv(PORTFOLIO_CSV)
-                    prev = prev[prev["Ticker"] == ticker].tail(1)
+                    prev = prev[prev["Ticker"] == ticker]
                     if not prev.empty:
-                        cp = prev["Current Price"].iloc[0]
+                        prev["Date"] = pd.to_datetime(prev["Date"], errors="coerce")
+                        prev = prev.sort_values("Date")
+                        cp = prev["Current Price"].iloc[-1]
                         if pd.notna(cp) and cp != "":
                             fallback_price = float(cp)
                 except Exception:  # pragma: no cover - defensive


### PR DESCRIPTION
## Summary
- Prevent fallback from grabbing earliest entry when portfolio CSV is unsorted.
- Always sort ticker history by date before using the last current price.

## Testing
- `pytest -q`
- `python -m py_compile portfolio_app/trading_script.py`


------
https://chatgpt.com/codex/tasks/task_e_6897c3c7320c832485956b3f7e2d9814