### PR TITLE
Enable CORS for Flask API

### DIFF
--- a/portfolio_app/app.py
+++ b/portfolio_app/app.py
@@ -1,5 +1,6 @@
 from flask import Flask, request, jsonify, send_from_directory, send_file, render_template
 from flask_bcrypt import Bcrypt
+from flask_cors import CORS
 import sqlite3
 import jwt
 from datetime import datetime, timedelta
@@ -22,6 +23,7 @@ except Exception:  # pragma: no cover - streamlit is optional
 app = Flask(__name__, static_folder=None)
 app.config['SECRET_KEY'] = os.getenv('SECRET_KEY', 'change-this-secret')
 bcrypt = Bcrypt(app)
+CORS(app)
 
 BASE_DIR = os.path.dirname(os.path.abspath(__file__))
 DATA_DIR = os.path.join(BASE_DIR, 'Scripts and CSV Files')

--- a/portfolio_app/requirements.txt
+++ b/portfolio_app/requirements.txt
@@ -6,3 +6,4 @@ Flask==3.0.2
 Flask-Bcrypt==1.0.1
 PyJWT==2.8.0
 mpld3>=0.5.9
+Flask-Cors==4.0.0


### PR DESCRIPTION
## Summary
- allow cross-origin requests by adding `flask_cors` and applying `CORS(app)`
- include `Flask-Cors` in requirements

## Testing
- `python -m py_compile portfolio_app/app.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6897e756fb708324b56aec7e57b523fc