### PR TITLE
Switch portfolio equity chart to frontend Chart.js

### DIFF
--- a/AI Website/ChatGPT-Micro-Cap-Experiment/templates/sample.html
+++ b/AI Website/ChatGPT-Micro-Cap-Experiment/templates/sample.html
@@ -3,8 +3,67 @@
 <head>
     <meta charset="UTF-8" />
     <title>Sample Portfolio</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom"></script>
+    <style>
+        .chart-container { position: relative; width: 100%; max-width: 800px; height: 400px; }
+    </style>
 </head>
 <body>
     <h1>Sample Portfolio Equity History</h1>
+    <div class="chart-container">
+        <canvas id="equityChart"></canvas>
+        <button id="resetZoom">Reset Zoom</button>
+    </div>
+    <script>
+    if (window.Chart && window.ChartZoom) { Chart.register(window.ChartZoom); }
+    (async () => {
+        const canvas = document.getElementById('equityChart');
+        const resetBtn = document.getElementById('resetZoom');
+        try {
+            const res = await fetch('/api/sample-equity-history');
+            if (!res.ok) throw new Error('Failed to load equity history');
+            const data = await res.json();
+            if (!Array.isArray(data) || data.length === 0) {
+                const msg = document.createElement('p');
+                msg.textContent = 'No data available';
+                canvas.replaceWith(msg);
+                resetBtn.remove();
+                return;
+            }
+            const points = data.map(d => ({ x: d.date, y: parseFloat(d.equity) }));
+            const chart = new Chart(canvas, {
+                type: 'line',
+                data: { datasets: [{ label: 'Equity', data: points, borderColor: '#1f77b4', backgroundColor: '#1f77b4', pointRadius:3, pointHoverRadius:5, pointBackgroundColor:'#1f77b4', pointHoverBackgroundColor:'#1f77b4', tension:0, fill:false }] },
+                options: {
+                    responsive: true,
+                    interaction: { mode: 'nearest', intersect: true },
+                    plugins: {
+                        tooltip: { callbacks: { label: ctx => `$${ctx.parsed.y.toFixed(2)}` } },
+                        zoom: { zoom: { wheel: { enabled: true, modifierKey: 'alt' }, mode: 'x' }, pan: { enabled: true, modifierKey: 'shift', mode: 'x' } }
+                    },
+                    onClick: (e, elements) => {
+                        if (elements.length) {
+                            const p = chart.data.datasets[0].data[elements[0].index];
+                            console.log({ date: p.x, equity: p.y });
+                        }
+                    },
+                    scales: {
+                        x: { type: 'time', time: { parser: 'yyyy-MM-dd', tooltipFormat: 'PP' }, ticks: { color: '#000' }, grid: { color: '#e0e0e0' } },
+                        y: { ticks: { color: '#000', callback: v => `$${v}` }, grid: { color: '#e0e0e0' } }
+                    }
+                }
+            });
+            resetBtn.onclick = () => chart.resetZoom();
+        } catch (err) {
+            console.error(err);
+            const msg = document.createElement('p');
+            msg.textContent = 'No data available';
+            canvas.replaceWith(msg);
+            resetBtn.remove();
+        }
+    })();
+    </script>
 </body>
 </html>

--- a/AI Website/ChatGPT-Micro-Cap-Experiment/templates/sample_portfolio.html
+++ b/AI Website/ChatGPT-Micro-Cap-Experiment/templates/sample_portfolio.html
@@ -30,9 +30,12 @@
             </div>
         </section>
         <section id="graphs">
-            
+
             <h2>Equity History</h2>
-            <img src="/sample_chart.png" width="800" height="400" alt="Sample portfolio equity history" />
+            <div class="chart-container">
+                <canvas id="equityChart"></canvas>
+                <button id="resetZoom">Reset Zoom</button>
+            </div>
         </section>
         <section id="portfolio">
             <h2>Portfolio</h2>
@@ -76,6 +79,9 @@
     <footer>
         <p>&copy; 2024 ChatGPT Micro-Cap Experiment. All rights reserved.</p>
     </footer>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom"></script>
     <script src="/sample_portfolio.js"></script>
     <script src="/sample_trade_log.js"></script>
 </body>

--- a/portfolio_app/index.html
+++ b/portfolio_app/index.html
@@ -56,7 +56,10 @@
 
         <section id="graphs">
             <h2>Portfolio vs Benchmark</h2>
-            <img id="equityChart" alt="Equity history chart" />
+            <div class="chart-container">
+                <canvas id="equityChart"></canvas>
+                <button id="resetZoom">Reset Zoom</button>
+            </div>
         </section>
 
         <section id="portfolio">
@@ -133,6 +136,9 @@
     <footer>
         <p>&copy; 2024 ChatGPT Micro-Cap Experiment. All rights reserved.</p>
     </footer>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom"></script>
     <script src="/script.js"></script>
 </body>
 </html>

--- a/portfolio_app/requirements.txt
+++ b/portfolio_app/requirements.txt
@@ -1,7 +1,6 @@
 numpy==1.26.4
 pandas==2.2.2
 yfinance==0.2.38
-matplotlib==3.8.4
 Flask==3.0.2
 Flask-Bcrypt==1.0.1
 PyJWT==2.8.0

--- a/portfolio_app/sample_portfolio.js
+++ b/portfolio_app/sample_portfolio.js
@@ -1,4 +1,9 @@
 document.addEventListener('DOMContentLoaded', () => {
+    if (window.Chart && window.ChartZoom) {
+        Chart.register(window.ChartZoom);
+    }
+    let equityChart;
+
     async function loadSamplePortfolio() {
         try {
             const res = await fetch('/api/sample-portfolio');
@@ -45,7 +50,97 @@ document.addEventListener('DOMContentLoaded', () => {
         }
     }
 
+    async function loadSampleEquityChart() {
+        const canvas = document.getElementById('equityChart');
+        const resetBtn = document.getElementById('resetZoom');
+        if (!canvas) return;
+        try {
+            const res = await fetch('/api/sample-equity-history');
+            if (!res.ok) throw new Error('Failed to load equity history');
+            const data = await res.json();
+            if (!Array.isArray(data) || data.length === 0) {
+                const msg = document.createElement('p');
+                msg.textContent = 'No data available';
+                canvas.replaceWith(msg);
+                if (resetBtn) resetBtn.remove();
+                return;
+            }
+            const points = data.map(d => ({ x: d.date, y: parseFloat(d.equity) }));
+            if (equityChart) equityChart.destroy();
+            equityChart = new Chart(canvas, {
+                type: 'line',
+                data: {
+                    datasets: [{
+                        label: 'Equity',
+                        data: points,
+                        borderColor: '#1f77b4',
+                        backgroundColor: '#1f77b4',
+                        pointRadius: 3,
+                        pointHoverRadius: 5,
+                        pointBackgroundColor: '#1f77b4',
+                        pointHoverBackgroundColor: '#1f77b4',
+                        fill: false,
+                        tension: 0,
+                    }]
+                },
+                options: {
+                    responsive: true,
+                    interaction: { mode: 'nearest', intersect: true },
+                    plugins: {
+                        tooltip: {
+                            callbacks: {
+                                label: ctx => `$${ctx.parsed.y.toFixed(2)}`
+                            }
+                        },
+                        zoom: {
+                            zoom: {
+                                wheel: { enabled: true, modifierKey: 'alt' },
+                                mode: 'x'
+                            },
+                            pan: {
+                                enabled: true,
+                                modifierKey: 'shift',
+                                mode: 'x'
+                            }
+                        }
+                    },
+                    onClick: (evt, elements) => {
+                        if (elements.length > 0) {
+                            const p = equityChart.data.datasets[0].data[elements[0].index];
+                            console.log({ date: p.x, equity: p.y });
+                        }
+                    },
+                    scales: {
+                        x: {
+                            type: 'time',
+                            time: { parser: 'yyyy-MM-dd', tooltipFormat: 'PP' },
+                            ticks: { color: '#000' },
+                            grid: { color: '#e0e0e0' }
+                        },
+                        y: {
+                            ticks: { color: '#000', callback: v => `$${v}` },
+                            grid: { color: '#e0e0e0' }
+                        }
+                    }
+                }
+            });
+            if (resetBtn) resetBtn.onclick = () => equityChart.resetZoom();
+        } catch (err) {
+            console.error(err);
+            const el = document.getElementById('errorMessage');
+            if (el) {
+                el.textContent = 'Failed to load equity chart';
+                el.classList.remove('visually-hidden');
+            }
+            const msg = document.createElement('p');
+            msg.textContent = 'No data available';
+            canvas.replaceWith(msg);
+            if (resetBtn) resetBtn.remove();
+        }
+    }
+
     loadSamplePortfolio();
+    loadSampleEquityChart();
 
     const token = localStorage.getItem('token');
     const processBtn = document.getElementById('processPortfolioBtn');

--- a/portfolio_app/styles.css
+++ b/portfolio_app/styles.css
@@ -101,6 +101,18 @@ main {
     padding: 1rem;
 }
 
+.chart-container {
+    position: relative;
+    width: 100%;
+    max-width: 800px;
+    height: 400px;
+    margin: 0 auto;
+}
+
+#resetZoom {
+    margin-top: 0.5rem;
+}
+
 .timeframe-buttons {
     margin-bottom: 1rem;
 }

--- a/portfolio_app/templates/sample.html
+++ b/portfolio_app/templates/sample.html
@@ -3,9 +3,70 @@
 <head>
     <meta charset="UTF-8" />
     <title>Sample Portfolio</title>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom"></script>
+    <style>
+        .chart-container { position: relative; width: 100%; max-width: 800px; height: 400px; }
+    </style>
 </head>
 <body>
     <h1>Sample Portfolio Equity History</h1>
-    <img src="{{ url_for('sample_chart_png') }}" alt="Equity history chart" />
+    <div class="chart-container">
+        <canvas id="equityChart"></canvas>
+        <button id="resetZoom">Reset Zoom</button>
+    </div>
+    <script>
+    if (window.Chart && window.ChartZoom) { Chart.register(window.ChartZoom); }
+    (async () => {
+        const canvas = document.getElementById('equityChart');
+        const resetBtn = document.getElementById('resetZoom');
+        try {
+            const res = await fetch('/api/sample-equity-history');
+            if (!res.ok) throw new Error('Failed to load equity history');
+            const data = await res.json();
+            if (!Array.isArray(data) || data.length === 0) {
+                const msg = document.createElement('p');
+                msg.textContent = 'No data available';
+                canvas.replaceWith(msg);
+                resetBtn.remove();
+                return;
+            }
+            const points = data.map(d => ({ x: d.date, y: parseFloat(d.equity) }));
+            const chart = new Chart(canvas, {
+                type: 'line',
+                data: { datasets: [{ label: 'Equity', data: points, borderColor: '#1f77b4', backgroundColor: '#1f77b4', pointRadius: 3, pointHoverRadius:5, pointBackgroundColor:'#1f77b4', pointHoverBackgroundColor:'#1f77b4', tension:0, fill:false }] },
+                options: {
+                    responsive: true,
+                    interaction: { mode: 'nearest', intersect: true },
+                    plugins: {
+                        tooltip: { callbacks: { label: ctx => `$${ctx.parsed.y.toFixed(2)}` } },
+                        zoom: {
+                            zoom: { wheel: { enabled: true, modifierKey: 'alt' }, mode: 'x' },
+                            pan: { enabled: true, modifierKey: 'shift', mode: 'x' }
+                        }
+                    },
+                    onClick: (e, elements) => {
+                        if (elements.length) {
+                            const p = chart.data.datasets[0].data[elements[0].index];
+                            console.log({ date: p.x, equity: p.y });
+                        }
+                    },
+                    scales: {
+                        x: { type: 'time', time: { parser: 'yyyy-MM-dd', tooltipFormat: 'PP' }, ticks: { color: '#000' }, grid: { color: '#e0e0e0' } },
+                        y: { ticks: { color: '#000', callback: v => `$${v}` }, grid: { color: '#e0e0e0' } }
+                    }
+                }
+            });
+            resetBtn.onclick = () => chart.resetZoom();
+        } catch (err) {
+            console.error(err);
+            const msg = document.createElement('p');
+            msg.textContent = 'No data available';
+            canvas.replaceWith(msg);
+            resetBtn.remove();
+        }
+    })();
+    </script>
 </body>
 </html>

--- a/portfolio_app/templates/sample_portfolio.html
+++ b/portfolio_app/templates/sample_portfolio.html
@@ -39,7 +39,10 @@
         </section>
         <section id="graphs">
             <h2>Equity History</h2>
-            <img src="/sample_chart.png" alt="Sample portfolio equity history" width="800" height="400" />
+            <div class="chart-container">
+                <canvas id="equityChart"></canvas>
+                <button id="resetZoom">Reset Zoom</button>
+            </div>
         </section>
         <section id="portfolio">
             <h2>Portfolio</h2>
@@ -83,6 +86,9 @@
     <footer>
         <p>&copy; 2024 ChatGPT Micro-Cap Experiment. All rights reserved.</p>
     </footer>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom"></script>
     <script src="/sample_portfolio.js"></script>
     <script src="/sample_trade_log.js"></script>
 </body>


### PR DESCRIPTION
## Summary
- use new `/api/portfolio-history` endpoint returning date/equity pairs
- render equity history in-browser with Chart.js, zoom/pan, tooltips, and reset button
- drop server-side matplotlib chart generation and dependency

## Testing
- `python -m py_compile portfolio_app/app.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6898066491a083249de6ea203f86dab2