### PR TITLE
Use Chart.js for interactive portfolio equity chart

### DIFF
--- a/portfolio_app/index.html
+++ b/portfolio_app/index.html
@@ -56,7 +56,11 @@
 
         <section id="graphs">
             <h2>Portfolio vs Benchmark</h2>
-            <img id="equityChart" alt="Equity history chart" />
+            <div id="equityChartWrapper" style="position: relative; height: 400px;">
+                <canvas id="equityChart"></canvas>
+                <p id="noDataMessage" class="visually-hidden">No data available</p>
+            </div>
+            <button id="resetZoomBtn" class="visually-hidden">Reset Zoom</button>
         </section>
 
         <section id="portfolio">
@@ -142,6 +146,9 @@
     <footer>
         <p>&copy; 2024 ChatGPT Micro-Cap Experiment. All rights reserved.</p>
     </footer>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom"></script>
     <script src="/script.js"></script>
 </body>
 </html>

--- a/portfolio_app/requirements.txt
+++ b/portfolio_app/requirements.txt
@@ -1,9 +1,7 @@
 numpy==1.26.4
 pandas==2.2.2
 yfinance==0.2.38
-matplotlib==3.8.4
 Flask==3.0.2
 Flask-Bcrypt==1.0.1
 PyJWT==2.8.0
-mpld3>=0.5.9
 SQLAlchemy==2.0.30


### PR DESCRIPTION
## Summary
- Replace server-rendered Matplotlib equity plot with responsive Chart.js canvas
- Expose `/api/portfolio-history` JSON endpoint and remove Matplotlib backend code
- Eliminate Matplotlib-related dependencies

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_689889cd25148324bed6c11214683f49