### PR TITLE
Handle missing ticker data during portfolio processing

### DIFF
--- a/portfolio_app/trading_script.py
+++ b/portfolio_app/trading_script.py
@@ -237,7 +237,11 @@ def process_portfolio(
             buy_price = float(pos.avg_price)
             cost_basis = buy_price * shares
             stop = float(pos.stop_loss or 0)
-            data = yf.Ticker(ticker).history(period="1d")
+            try:
+                data = yf.Ticker(ticker).history(period="1d")
+            except Exception as e:  # pragma: no cover - network errors
+                print(f"Failed to get ticker '{ticker}' reason: {e}")
+                data = pd.DataFrame()
             if data.empty:
                 row = {
                     "Date": today,


### PR DESCRIPTION
## Summary
- prevent crashes when yfinance fails to return data for a ticker
- log failed ticker retrievals and continue processing

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_6898922a34f883249a5b5b952cd851d0