### PR TITLE
Add retry and fallback for ticker pricing

### DIFF
--- a/portfolio_app/app.py
+++ b/portfolio_app/app.py
@@ -8,7 +8,6 @@ from functools import wraps
 import os
 import csv
 from typing import Tuple, Any
-import yfinance as yf
 from pathlib import Path
 from werkzeug.exceptions import HTTPException
 
@@ -147,13 +146,9 @@ def user_needs_cash(user_id: int) -> bool:
 
 
 def is_valid_ticker(ticker: str) -> bool:
-    """Return True if ``ticker`` has market data via yfinance."""
+    """Return True if ``ticker`` has market data from any source."""
 
-    try:
-        data = yf.Ticker(ticker).history(period="1d")
-        return not data.empty
-    except Exception:
-        return False
+    return ts.is_valid_ticker(ticker)
 
 
 def init_db():


### PR DESCRIPTION
## Summary
- add `fetch_history_with_retry` with retry logic and `price_fallback` secondary data source
- mark tickers as delisted only when both primary and fallback sources fail
- delegate API `is_valid_ticker` checks to trading script's resilient logic

## Testing
- `python -m py_compile portfolio_app/trading_script.py portfolio_app/app.py`


------
https://chatgpt.com/codex/tasks/task_e_689899c020e483249ac65f3b64197a2e