### PR TITLE
Expand yfinance download window

### DIFF
--- a/portfolio_app/app.py
+++ b/portfolio_app/app.py
@@ -191,8 +191,11 @@ def get_close_price(
     if mode == "force":
         target_date = _prev_trading_day(target_date)
 
-    start = target_date - timedelta(days=3)
-    end = target_date + timedelta(days=1)
+    # Extend download window to reduce Yahoo Finance empty responses on force
+    # processing. A broader timeframe increases the chance of retrieving data
+    # for symbols that might otherwise fail due to narrow ranges.
+    start = target_date - timedelta(days=7)
+    end = target_date + timedelta(days=2)
     df = _safe_download(t, start, end)
     if df is not None and not df.empty:
         try:


### PR DESCRIPTION
## Summary
- widen Yahoo Finance download timeframe for price lookups to cover more days
- add comments on broader window

## Testing
- `PYTHONPATH=. pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6898c61bacbc8324b2bb2324a16d88b2