### PR TITLE
Fix equity history unique constraint for forced processing

### DIFF
--- a/portfolio_app/__init__.py
+++ b/portfolio_app/__init__.py
@@ -1,0 +1,1 @@
+"""Portfolio application package."""

--- a/portfolio_app/db.py
+++ b/portfolio_app/db.py
@@ -19,15 +19,11 @@ def init_db() -> None:
         insp = inspect(conn)
         if insp.has_table("equity_history"):
             columns = [col["name"] for col in insp.get_columns("equity_history")]
+
             if "user_id" not in columns:
                 conn.execute(text("ALTER TABLE equity_history ADD COLUMN user_id INTEGER"))
                 conn.execute(text("UPDATE equity_history SET user_id = 1 WHERE user_id IS NULL"))
-                conn.execute(text("DROP INDEX IF EXISTS uix_equity_history_user_date"))
-                conn.execute(
-                    text(
-                        "CREATE UNIQUE INDEX uix_equity_history_user_date ON equity_history (user_id, date)"
-                    )
-                )
+
             if "process_type" not in columns:
                 conn.execute(
                     text(
@@ -39,6 +35,7 @@ def init_db() -> None:
                         "UPDATE equity_history SET process_type = 'regular' WHERE process_type IS NULL"
                     )
                 )
+
             if "is_final" not in columns:
                 conn.execute(
                     text(
@@ -48,5 +45,58 @@ def init_db() -> None:
                 conn.execute(
                     text(
                         "UPDATE equity_history SET is_final = 1 WHERE is_final IS NULL"
+                    )
+                )
+
+            # Ensure the correct composite unique index exists and no legacy
+            # single-column constraint on date remains. Older databases had
+            # ``date`` marked as UNIQUE which conflicts with our upsert logic.
+            uniques = insp.get_unique_constraints("equity_history")
+            legacy_date_unique = any(uc.get("column_names") == ["date"] for uc in uniques)
+
+            if legacy_date_unique:
+                # Rebuild the table without the obsolete UNIQUE constraint.
+                conn.execute(text("ALTER TABLE equity_history RENAME TO equity_history_old"))
+                conn.execute(
+                    text(
+                        """
+                        CREATE TABLE equity_history (
+                            id INTEGER PRIMARY KEY,
+                            user_id INTEGER,
+                            date DATE,
+                            portfolio_equity NUMERIC(18, 6),
+                            benchmark_equity NUMERIC(18, 6),
+                            process_type VARCHAR(10) DEFAULT 'regular',
+                            is_final BOOLEAN DEFAULT 1
+                        )
+                        """
+                    )
+                )
+                conn.execute(
+                    text(
+                        """
+                        INSERT INTO equity_history (id, user_id, date, portfolio_equity, benchmark_equity, process_type, is_final)
+                        SELECT id,
+                               COALESCE(user_id, 1),
+                               date,
+                               portfolio_equity,
+                               benchmark_equity,
+                               COALESCE(process_type, 'regular'),
+                               COALESCE(is_final, 1)
+                        FROM equity_history_old
+                        """
+                    )
+                )
+                conn.execute(text("DROP TABLE equity_history_old"))
+
+            indexes = insp.get_indexes("equity_history")
+            has_user_date_index = any(
+                idx.get("unique") and idx.get("column_names") == ["user_id", "date"]
+                for idx in indexes
+            )
+            if not has_user_date_index:
+                conn.execute(
+                    text(
+                        "CREATE UNIQUE INDEX uix_equity_history_user_date ON equity_history (user_id, date)"
                     )
                 )


### PR DESCRIPTION
## Summary
- repair equity history migrations and ensure composite unique index on `(user_id, date)`
- add missing `__init__` so `portfolio_app` can be imported as a package

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6898d7c836788324a64d1989f5328344