### PR TITLE
Fix equity chart rendering by parsing dates safely

### DIFF
--- a/portfolio_app/index.html
+++ b/portfolio_app/index.html
@@ -147,8 +147,9 @@
         <p>&copy; 2024 ChatGPT Micro-Cap Experiment. All rights reserved.</p>
     </footer>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+    <!-- Time adapter for Chart.js -->
     <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns"></script>
     <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom"></script>
     <script src="/script.js"></script>
-</body>
+  </body>
 </html>


### PR DESCRIPTION
## Summary
- Ensure Chart.js time adapter is loaded
- Rework `loadEquityChart` to build validated `Date`/`number` points and update or destroy the chart with helpful messages
- Support custom timeouts in `fetchJson`

## Testing
- `PYTHONPATH=$PWD pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_689902fbd33c8324bd4863e7d88d3d23