### PR TITLE
Enhance equity chart history handling

### DIFF
--- a/portfolio_app/index.html
+++ b/portfolio_app/index.html
@@ -147,7 +147,7 @@
         <p>&copy; 2024 ChatGPT Micro-Cap Experiment. All rights reserved.</p>
     </footer>
     <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
-    <!-- Time adapter for Chart.js -->
+    <!-- Time adapter for Chart.js (must load after Chart.js) -->
     <script src="https://cdn.jsdelivr.net/npm/chartjs-adapter-date-fns"></script>
     <script src="https://cdn.jsdelivr.net/npm/chartjs-plugin-zoom"></script>
     <script src="/script.js"></script>


### PR DESCRIPTION
## Summary
- Ensure Chart.js date adapter loads after the core library
- Normalize and upsert equity history points on the client
- Refresh chart data after processing portfolio updates

## Testing
- `PYTHONPATH=. pytest tests/test_price_fallback.py -q`


------
https://chatgpt.com/codex/tasks/task_e_6899fccd874883248953ba63b6b4e794