### PR TITLE
Remove redundant portfolio totals metrics

### DIFF
--- a/portfolio_app/index.html
+++ b/portfolio_app/index.html
@@ -84,13 +84,6 @@
                     <tbody id="portfolioTableBody"></tbody>
                 </table>
             </div>
-            <div id="portfolioTotals">
-                <p>Cash: <span id="totalsCash">--</span></p>
-                <p>Positions Value: <span id="totalsPositionsValue">--</span></p>
-                <p>PnL: <span id="totalsPnl">--</span></p>
-                <p>Total Equity: <span id="totalsTotalEquity">--</span></p>
-                <p id="asOfCaption"></p>
-            </div>
         </section>
 
         <section id="trade-form">

--- a/portfolio_app/script.js
+++ b/portfolio_app/script.js
@@ -281,17 +281,7 @@ document.addEventListener('DOMContentLoaded', () => {
     const totals = data.totals || {};
     const cash = Number(totals.cash ?? 0);
     const posVal = Number(totals.total_positions_value ?? 0);
-    const pnl = Number(totals.total_pnl ?? 0);
     const totalEq = Number(totals.total_equity ?? 0);
-
-    const cashEl = document.getElementById('totalsCash');
-    if (cashEl) cashEl.textContent = `$${cash.toFixed(2)}`;
-    const posValEl = document.getElementById('totalsPositionsValue');
-    if (posValEl) posValEl.textContent = `$${posVal.toFixed(2)}`;
-    const pnlEl = document.getElementById('totalsPnl');
-    if (pnlEl) pnlEl.textContent = `$${pnl.toFixed(2)}`;
-    const totalEqEl = document.getElementById('totalsTotalEquity');
-    if (totalEqEl) totalEqEl.textContent = `$${totalEq.toFixed(2)}`;
 
     const totalTop = document.getElementById('totalEquity');
     if (totalTop) totalTop.textContent = `$${totalEq.toFixed(2)}`;
@@ -306,8 +296,6 @@ document.addEventListener('DOMContentLoaded', () => {
       eqChangeEl.textContent = `(${change.toFixed(2)}%)`;
     }
 
-    const caption = document.getElementById('asOfCaption');
-    if (caption) caption.textContent = `As of ${data.as_of_date_et}${data.forced ? ' (forced)' : ''}`;
   }
 
   async function loadTradeLog() {


### PR DESCRIPTION
## Summary
- Remove Cash, Positions Value, PnL, Total Equity, and timestamp block from Portfolio section to streamline layout.
- Strip associated JavaScript updates for removed metrics, keeping top dashboard summaries intact.

## Testing
- `PYTHONPATH=. pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_6899ffd05a9c8324a288d11cd7255e36