### PR TITLE
Respect date ranges and validate response types

### DIFF
--- a/portfolio_app/script.js
+++ b/portfolio_app/script.js
@@ -123,8 +123,24 @@ document.addEventListener('DOMContentLoaded', () => {
     }
   }
 
-  async function ensureOk(res, fallback, opts) {
-    if (res.ok) return;
+  async function ensureOk(res, fallback, opts = {}) {
+    const { expectContentType } = opts;
+
+    if (res.ok) {
+      // Even when the status is OK, the server might have responded with an
+      // unexpected content type.  Previously this check was skipped which
+      // meant callers attempting to parse JSON could fail with a cryptic
+      // error.  Verify the content type and surface a clear message instead.
+      if (expectContentType) {
+        const ct = res.headers.get('content-type') || '';
+        if (!ct.includes(expectContentType)) {
+          const msg = await getErrorMessage(res, fallback, { expectContentType });
+          throw new Error(msg);
+        }
+      }
+      return;
+    }
+
     const msg = await getErrorMessage(res, fallback, opts);
     if (res.status === 401) {
       // Token likely expired — clear and redirect


### PR DESCRIPTION
## Summary
- ensure `_safe_download` honours provided start/end dates for deterministic price queries
- surface clear errors when responses return unexpected content types in the web client

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689a52c927fc83249c8d4af998858bc9